### PR TITLE
Fix sort ordering logic

### DIFF
--- a/src/app/execution/txHelper.js
+++ b/src/app/execution/txHelper.js
@@ -32,6 +32,9 @@ module.exports = {
   },
 
   sortAbiFunction: function (contractabi) {
+    // Sorts the list of ABI entries. Constant functions will appear first,
+    // followed by non-constant functions. Within those t wo groupings, functions
+    // will be sorted by their names.
     return contractabi.sort(function (a, b) {
       if (a.constant === true && b.constant !== true) {
         return 1

--- a/src/app/execution/txHelper.js
+++ b/src/app/execution/txHelper.js
@@ -32,16 +32,17 @@ module.exports = {
   },
 
   sortAbiFunction: function (contractabi) {
-    var abi = contractabi.sort(function (a, b) {
-      if (a.name > b.name) {
-        return -1
-      } else {
-        return 1
+    return contractabi.sort(function (a, b) {
+      if (a.constant === true && b.constant !== true) {
+        return 1;
+      } else if (b.constant === true && a.constant !== true) {
+        return -1;
       }
-    }).sort(function (a, b) {
-      if (a.constant === true) {
-        return -1
-      } else {
+      // If we reach here, either a and b are both constant or both not; sort by name then
+      // special case for fallback and constructor
+      if (a.type === 'function' && typeof a.name !== 'undefined') {
+        return a.name.localeCompare(b.name)
+      } else if (a.type === 'constructor' || a.type === 'fallback') {
         return 1
       }
     })

--- a/src/app/execution/txHelper.js
+++ b/src/app/execution/txHelper.js
@@ -34,9 +34,9 @@ module.exports = {
   sortAbiFunction: function (contractabi) {
     return contractabi.sort(function (a, b) {
       if (a.constant === true && b.constant !== true) {
-        return 1;
+        return 1
       } else if (b.constant === true && a.constant !== true) {
-        return -1;
+        return -1
       }
       // If we reach here, either a and b are both constant or both not; sort by name then
       // special case for fallback and constructor
@@ -46,7 +46,6 @@ module.exports = {
         return 1
       }
     })
-    return abi
   },
 
   getConstructorInterface: function (abi) {


### PR DESCRIPTION
Having two separate `sort` calls doesn't actually preserve the ordering of the first sort (by name) so only the second (constant vs. not) was being sorted on properly. This fix first checks to see if the two items have different `constant` values, and only if their `constant` values are the same does it then sort by name.