### PR TITLE
Update nightwatch.js

### DIFF
--- a/nightwatch.js
+++ b/nightwatch.js
@@ -69,6 +69,17 @@ module.exports = {
         'tunnel-identifier': 'browsersolidity_tests_' + TRAVIS_JOB_NUMBER
       }
     },
+    
+    'opera': {
+      'desiredCapabilities': {
+        'browserName': 'opera',
+        'javascriptEnabled': true,
+        'acceptSslCerts': true,
+        'version': '12.15',
+        'build': 'build-' + TRAVIS_JOB_NUMBER,
+        'tunnel-identifier': 'browsersolidity_tests_' + TRAVIS_JOB_NUMBER
+      }
+    }
 
     'local': {
       'launch_url': 'http://localhost:8080',


### PR DESCRIPTION
add opera browser to module.exports object
lastest version 12.15
available for Windows 10 , OS X 10.11, Linux v8.01