### PR TITLE
use normalize path to retrieve content

### DIFF
--- a/src/app/files/basicReadOnlyExplorer.js
+++ b/src/app/files/basicReadOnlyExplorer.js
@@ -28,6 +28,7 @@ class BasicReadOnlyExplorer {
   }
 
   get (path, cb) {
+    if (this.normalizedNames[path]) path = this.normalizedNames[path] // ensure we actually use the normalized path from here
     var unprefixedPath = this.removePrefix(path)
     var content = this.files[unprefixedPath]
     if (!content) {


### PR DESCRIPTION
normalized path is something like:
`github/ethereum/ens/contracts/ENS.sol`
the raw path is
`https://github.com/ethereum/ens/contracts/ENS.sol`

that PR allows to use `get` with the raw path