### PR TITLE
Show pending modal for long-lasting transactions

### DIFF
--- a/src/app/ui/modaldialog.js
+++ b/src/app/ui/modaldialog.js
@@ -12,9 +12,11 @@ module.exports = (title, content, ok, cancel) => {
 
   var okDiv = document.getElementById('modal-footer-ok')
   okDiv.innerHTML = (ok && ok.label !== undefined) ? ok.label : 'OK'
+  ok && ok.hide && okDiv.parentNode.removeChild(okDiv)
 
   var cancelDiv = document.getElementById('modal-footer-cancel')
   cancelDiv.innerHTML = (cancel && cancel.label !== undefined) ? cancel.label : 'Cancel'
+  cancel && cancel.hide && cancelDiv.parentNode.removeChild(cancelDiv)
 
   var modal = document.querySelector(`.${css.modalBody}`)
   var modalTitle = document.querySelector(`.${css.modalHeader} h2`)


### PR DESCRIPTION
This PR adds logic to show a modal that informs the user that a transaction is still pending if it takes longer than 10 seconds.

<img width="476" alt="modal" src="https://user-images.githubusercontent.com/334586/37600981-4a503e4e-2b5f-11e8-8b78-4f671f9577ec.png">

Resolves #1103 