### PR TITLE
Use request module for all XHR requests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ var $ = require('jquery')
 var csjs = require('csjs-inject')
 var yo = require('yo-yo')
 var async = require('async')
+var request = require('request')
 var remixLib = require('remix-lib')
 var EventManager = remixLib.EventManager
 
@@ -584,19 +585,15 @@ Please make a backup of your contracts and start using http://remix.ethereum.org
   // ------------------ gist load ----------------
   function loadFromGist (gistId) {
     return gistHandler.handleLoad(gistId, function (gistId) {
-      $.ajax({
-        url: 'https://api.github.com/gists/' + gistId,
-        jsonp: 'callback',
-        dataType: 'jsonp',
-        success: function (response) {
-          if (response.data) {
-            if (!response.data.files) {
-              modalDialogCustom.alert('Gist load error: ' + response.data.message)
-              return
-            }
-            loadFiles(response.data.files, 'gist')
-          }
+      request.get({
+        url: `https://api.github.com/gists/${gistId}`,
+        json: true
+      }, (error, response, data = {}) => {
+        if (error || !data.files) {
+          modalDialogCustom.alert(`Gist load error: ${error || data.message}`)
+          return
         }
+        loadFiles(data.files, 'gist')
       })
     })
   }

--- a/src/app/tabs/settings-tab.js
+++ b/src/app/tabs/settings-tab.js
@@ -192,6 +192,8 @@ function SettingsTab (appAPI = {}, appEvents = {}, opts = {}) {
   }, (error, response, data) => {
     if (error || !data) {
       tooltip('Cannot load compiler version list. It might have been blocked by an advertisement blocker. Please try deactivating any of them from this page and reload.')
+
+      // loading failed for some reason, fall back to local compiler
       versionSelector.append(new Option('latest local version', 'builtin'))
       loadVersion('builtin', queryParams, appAPI, el)
       return


### PR DESCRIPTION
This PR removes the remaining two uses of jQuery for XHR requests and replaces them with `request.get` calls.

Resolves #1116 