### PR TITLE
Move http-server from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "exorcist": "^0.4.0",
     "fast-async": "^6.1.2",
     "fast-levenshtein": "^2.0.6",
-    "http-server": "0.9.0",
     "javascript-serialize": "^1.6.1",
     "jquery": "^3.3.1",
     "js-base64": "^2.1.9",
@@ -55,6 +54,7 @@
     "yo-yoify": "^3.1.0"
   },
   "dependencies": {
+    "http-server": "0.9.0",
     "remixd": "git+https://github.com/ethereum/remixd.git"
   },
   "repository": {


### PR DESCRIPTION
This PR fixes an issue with the `remix-ide` package when installed globally where `http-server` can't be found. `http-server`should be a `dependency`, not a `devDependency`, so `http-server` will always be installed as expected, even when the `--production` flag is passed.

Resolves #1193