### PR TITLE
Show one context menu at a time

### DIFF
--- a/src/app/files/file-explorer.js
+++ b/src/app/files/file-explorer.js
@@ -10,6 +10,8 @@ var helper = require('../../lib/helper')
 
 var css = require('./styles/file-explorer-styles')
 
+let MENU_HANDLE
+
 function fileExplorer (appAPI, files) {
   var self = this
   this.events = new EventManager()
@@ -119,7 +121,8 @@ function fileExplorer (appAPI, files) {
   })
 
   self.treeView.event.register('nodeRightClick', function (key, data, label, event) {
-    contextMenu(event, {
+    MENU_HANDLE && MENU_HANDLE.hide(null, true)
+    MENU_HANDLE = contextMenu(event, {
       'Rename': () => {
         if (self.files.readonly) { return addTooltip('cannot rename folder. ' + self.files.type + ' is a read only explorer') }
         var name = label.querySelector('label[data-path="' + key + '"]')
@@ -133,7 +136,8 @@ function fileExplorer (appAPI, files) {
   })
 
   self.treeView.event.register('leafRightClick', function (key, data, label, event) {
-    contextMenu(event, {
+    MENU_HANDLE && MENU_HANDLE.hide(null, true)
+    MENU_HANDLE = contextMenu(event, {
       'Rename': () => {
         if (self.files.readonly) { return addTooltip('cannot rename file. ' + self.files.type + ' is a read only explorer') }
         var name = label.querySelector('label[data-path="' + key + '"]')

--- a/src/app/ui/contextMenu.js
+++ b/src/app/ui/contextMenu.js
@@ -65,4 +65,6 @@ module.exports = (event, items) => {
   setTimeout(() => {
     window.addEventListener('click', hide)
   }, 500)
+
+  return { hide }
 }


### PR DESCRIPTION
This PR fixes a UX issue where multiple right-click context menus were showing at a given time. `contextMenu` was updated to return a handle that exposes its `hide` function, and `file-explorer` was updated to cache a singleton reference to the last-opened context menu. This handle is used to hide any existing context menu before opening a new one.

Resolves #1092