### PR TITLE
Fix installation: pin fast-async at v6.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ethereumjs-util": "^5.1.2",
     "execr": "^1.0.1",
     "exorcist": "^0.4.0",
-    "fast-async": "^6.1.2",
+    "fast-async": "6.3.1",
     "fast-levenshtein": "^2.0.6",
     "javascript-serialize": "^1.6.1",
     "jquery": "^3.3.1",


### PR DESCRIPTION
Running `npm install` on the current `master` branch fails due to the `fast-async` dependency introducing an upstream bug (see  MatAtBread/fast-async#53.) To alleviate the issue immediately, this PR pins `fast-async` to `v6.3.1`, the last working version. CI was most likely passing due to its `node_modules` being aggressively cached, fwiw.

Resolves #1216 and resolves #1220