### PR TITLE
Fixed delegation loop condition

### DIFF
--- a/contracts/ballot.sol
+++ b/contracts/ballot.sol
@@ -84,7 +84,7 @@ contract Ballot {
         }
 
         // We found a loop in the delegation, not allowed.
-        if (to == msg.sender) {
+        if (voters[to].delegate == msg.sender) {
             throw;
         }
 


### PR DESCRIPTION
When the while clause "voters[to].delegate != msg.sender" breaks the loop, the instruction assigning that to "to" is not executed.