### PR TITLE
Override control-s and command-s to auto-recompile

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -235,6 +235,14 @@ Please make a backup of your contracts and start using http://remix.ethereum.org
     return 'Are you sure you want to leave?'
   }
 
+  // Run the compiler instead of trying to save the website
+  $(window).keydown(function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.keyCode == 83) { /*ctrl+s or command+s*/
+      e.preventDefault();
+      runCompiler();
+    }
+  });
+
   function importExternal (url, cb) {
     self._components.compilerImport.import(url,
       (loadingMsg) => {

--- a/src/app.js
+++ b/src/app.js
@@ -237,11 +237,12 @@ Please make a backup of your contracts and start using http://remix.ethereum.org
 
   // Run the compiler instead of trying to save the website
   $(window).keydown(function (e) {
-    if ((e.metaKey || e.ctrlKey) && e.keyCode == 83) { /*ctrl+s or command+s*/
-      e.preventDefault();
-      runCompiler();
+    // ctrl+s or command+s
+    if ((e.metaKey || e.ctrlKey) && e.keyCode === 83) {
+      e.preventDefault()
+      runCompiler()
     }
-  });
+  })
 
   function importExternal (url, cb) {
     self._components.compilerImport.import(url,


### PR DESCRIPTION
### The problem this solves?

Remix is treated by many as their main text editor for solidity smart contracts. Therefore it should act as a conventional text editor. This PR acts as a hot-reloading tool by overriding command+save and control+save to auto-recompile the editor. Up until now this would cause the browser to attempt to download the remix ide website.

### What changed?
Only 8 lines in `./src/app.js` (line 238 - 245). It uses the window object to capture keypresses for those specific keys to trigger the recompile function found in `app.js`.
