### PR TITLE
Add ability to filter out compiler warnings

### DIFF
--- a/src/app/tabs/compile-tab.js
+++ b/src/app/tabs/compile-tab.js
@@ -29,13 +29,13 @@ module.exports = class CompileTab {
       contractEl: null
     }
     self.data = {
+      hideWarnings: self._opts.config.get('hideWarnings') || false,
       autoCompile: self._opts.config.get('autoCompile'),
       compileTimeout: null,
       contractsDetails: {},
       maxTime: 1000,
       timeout: 300
     }
-    self._opts.config.set('hideWarnings', false)
     self._events.editor.register('contentChanged', scheduleCompilation)
     self._events.editor.register('sessionSwitched', scheduleCompilation)
     function scheduleCompilation () {
@@ -146,6 +146,7 @@ module.exports = class CompileTab {
     self._view.autoCompile = yo`<input class="${css.autocompile}" onchange=${updateAutoCompile} id="autoCompile" type="checkbox" title="Auto compile">`
     self._view.hideWarningsBox = yo`<input class="${css.autocompile}" onchange=${hideWarnings} id="hideWarningsBox" type="checkbox" title="Hide warnings">`
     if (self.data.autoCompile) self._view.autoCompile.setAttribute('checked', '')
+    if (self.data.hideWarnings) self._view.hideWarningsBox.setAttribute('checked', '')
     self._view.compileContainer = yo`
       <div class="${css.compileContainer}">
         <div class="${css.compileButtons}">
@@ -194,7 +195,7 @@ module.exports = class CompileTab {
     function updateAutoCompile (event) { self._opts.config.set('autoCompile', self._view.autoCompile.checked) }
     function compile (event) { self._api.runCompiler() }
     function hideWarnings (event) {
-      self._opts.config.set('hideWarnings', !self._opts.config.get('hideWarnings'))
+      self._opts.config.set('hideWarnings', self._view.hideWarningsBox.checked)
       self._api.runCompiler()
     }
     function details () {

--- a/src/app/tabs/compile-tab.js
+++ b/src/app/tabs/compile-tab.js
@@ -294,11 +294,6 @@ const css = csjs`
     display: flex;
     align-items: center;
   }
-  .hideWarningsContainer {
-    display: flex;
-    align-items: center;
-    margin-left: 2%
-  }
   .autocompile {}
   .autocompileTitle {
     font-weight: bold;

--- a/src/universal-dapp-styles.js
+++ b/src/universal-dapp-styles.js
@@ -241,6 +241,11 @@ var css = csjs`
     padding-right: 26px;
     padding-top: 5px;
     float: right;
+  },
+  .hideWarningsContainer {
+    display: flex;
+    align-items: center;
+    margin-left: 2%
   }
 `
 


### PR DESCRIPTION
Hey guys!

I'm back with a UX feature...


### The problem this solves?
On compile remix renders a lot of errors that are typically not important, and from what I've gathered from around the community, commonly ignored. What happens is these yellow warnings hide the critical (red warnings). In order to combat this, I added a checkbox, identical to the `auto-compile` checkbox, that will remove the yellow warnings exposing only the red.

### What changed?
Only `compile-tab.js` changed, to be honest I'm not sure if this is the best way to go about the state within the module, but I store to `self._opts.config.set('hideWarnings', false)`. When the errors are rendered I added a bit of logic to filter yellow when checked and added a style.

~I'm wondering if perhaps there is a better place to set the inital state of the checkbox? I tried digging through `app.js` and `righthand-pannel.js` which use `compile-tab.js` but couldn't identify the right spot.~

### NOTE
There are a few tests ~5 that are failing due to them expecting to see a warning but none was generated. If this looks like something that you want to merge I'll be more than happy to fix those tests up!

EDIT 1:
Got the checkbox state to persist on page refresh.


Cheers!