### PR TITLE
Use Buffer.from instead of new Buffer

### DIFF
--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -83,7 +83,7 @@ UniversalDApp.prototype.resetAPI = function (transactionContextAPI) {
 UniversalDApp.prototype.createVMAccount = function (privateKey, balance, cb) {
   this._addAccount(privateKey, balance)
   executionContext.vm().stateManager.cache.flush(function () {})
-  privateKey = new Buffer(privateKey, 'hex')
+  privateKey = Buffer.from(privateKey, 'hex')
   cb(null, '0x' + ethJSUtil.privateToAddress(privateKey).toString('hex'))
 }
 
@@ -118,7 +118,7 @@ UniversalDApp.prototype._addAccount = function (privateKey, balance) {
   }
 
   if (self.accounts) {
-    privateKey = new Buffer(privateKey, 'hex')
+    privateKey = Buffer.from(privateKey, 'hex')
     var address = ethJSUtil.privateToAddress(privateKey)
 
     // FIXME: we don't care about the callback, but we should still make this proper
@@ -165,7 +165,7 @@ UniversalDApp.prototype.getBalance = function (address, cb) {
       return cb('No accounts?')
     }
 
-    executionContext.vm().stateManager.getAccountBalance(new Buffer(address, 'hex'), function (err, res) {
+    executionContext.vm().stateManager.getAccountBalance(Buffer.from(address, 'hex'), function (err, res) {
       if (err) {
         cb('Account not found')
       } else {


### PR DESCRIPTION
#### What does it do?
This PR replaces all `new Buffer` with `Buffer.from`. We should not use Buffer constructor which is deprecated and unsafe.

#### Any helpful background information?
The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe