### PR TITLE
Introduce custom ACE themes, change 1 color to illustrate process

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
   "standard": {
     "ignore": [
       "build/",
-      "src/app/editor/mode-solidity.js",
+      "src/app/editor/styles/theme-solid_blue.js",
+      "src/app/editor/styles/theme-solid_light.js",
       "soljson.js"
     ],
     "parser": "babel-eslint"

--- a/src/app/editor/editor.js
+++ b/src/app/editor/editor.js
@@ -5,7 +5,7 @@ var yo = require('yo-yo')
 var csjs = require('csjs-inject')
 var ace = require('brace')
 
-require('brace/theme/tomorrow_night_blue')
+// require('brace/theme/tomorrow_night_blue')
 
 var globalRegistry = require('../../global/registry')
 
@@ -17,18 +17,20 @@ require('ace-mode-solidity/build/remix-ide/mode-solidity')
 require('brace/mode/javascript')
 require('brace/mode/python')
 require('brace/mode/json')
+require('./styles/theme-solid_blue')
+require('./styles/theme-solid_light')
 var styleGuide = require('../ui/styles-guide/theme-chooser')
 var styles = styleGuide.chooser()
 
-function setTheme (cb) {
-  if (styles.appProperties.aceTheme) {
-    cb('brace/theme/', styles.appProperties.aceTheme)
-  }
-}
-
-setTheme((path, theme) => {
-  require('brace/theme/tomorrow_night_blue')
-})
+// function setTheme (cb) {
+//   if (styles.appProperties.aceTheme) {
+//     cb('brace/theme/', styles.appProperties.aceTheme)
+//   }
+// }
+//
+// setTheme((path, theme) => {
+//   require('brace/theme/tomorrow_night_blue')
+// })
 
 var css = csjs`
   .ace-editor {

--- a/src/app/editor/styles/theme-solid_blue.js
+++ b/src/app/editor/styles/theme-solid_blue.js
@@ -1,0 +1,137 @@
+var styles = require('../../ui/styles-guide/styleGuideDark')()
+
+// based on @see https://github.com/thlorenz/brace/blob/v0.8.0/theme/tomorrow_night_blue.js
+var aceThemeSolidBlueCssText = `
+.ace-solid-blue .ace_gutter {
+  background: #00204b;
+  color: #7388b5
+}
+
+.ace-solid-blue .ace_print-margin {
+  width: 1px;
+  background: #00204b
+}
+
+.ace-solid-blue {
+  background-color: #002451;
+  color: #FFFFFF
+}
+
+.ace-solid-blue .ace_constant.ace_other,
+.ace-solid-blue .ace_cursor {
+  color: #FFFFFF
+}
+
+.ace-solid-blue .ace_marker-layer .ace_selection {
+  background: #003F8E
+}
+
+.ace-solid-blue.ace_multiselect .ace_selection.ace_start {
+  box-shadow: 0 0 3px 0px #002451;
+}
+
+.ace-solid-blue .ace_marker-layer .ace_step {
+  background: rgb(127, 111, 19)
+}
+
+.ace-solid-blue .ace_marker-layer .ace_bracket {
+  margin: -1px 0 0 -1px;
+  border: 1px solid #404F7D
+}
+
+.ace-solid-blue .ace_marker-layer .ace_active-line {
+  background: #00346E
+}
+
+.ace-solid-blue .ace_gutter-active-line {
+  background-color: #022040
+}
+
+.ace-solid-blue .ace_marker-layer .ace_selected-word {
+  border: 1px solid #003F8E
+}
+
+.ace-solid-blue .ace_invisible {
+  color: #404F7D
+}
+
+.ace-solid-blue .ace_keyword,
+.ace-solid-blue .ace_meta,
+.ace-solid-blue .ace_storage,
+.ace-solid-blue .ace_storage.ace_type,
+.ace-solid-blue .ace_support.ace_type {
+  color: #EBBBFF
+}
+
+.ace-solid-blue .ace_keyword.ace_operator {
+  color: #99FFFF
+}
+
+.ace-solid-blue .ace_constant.ace_character,
+.ace-solid-blue .ace_constant.ace_language,
+.ace-solid-blue .ace_constant.ace_numeric,
+.ace-solid-blue .ace_keyword.ace_other.ace_unit,
+.ace-solid-blue .ace_support.ace_constant,
+.ace-solid-blue .ace_variable.ace_parameter {
+  color: #FFC58F
+}
+
+.ace-solid-blue .ace_invalid {
+  color: #FFFFFF;
+  background-color: #F99DA5
+}
+
+.ace-solid-blue .ace_invalid.ace_deprecated {
+  color: #FFFFFF;
+  background-color: #EBBBFF
+}
+
+.ace-solid-blue .ace_fold {
+  background-color: #BBDAFF;
+  border-color: #FFFFFF
+}
+
+.ace-solid-blue .ace_entity.ace_name.ace_function,
+.ace-solid-blue .ace_support.ace_function,
+.ace-solid-blue .ace_variable {
+  color: #BBDAFF
+}
+
+.ace-solid-blue .ace_support.ace_class,
+.ace-solid-blue .ace_support.ace_type {
+  color: #FFEEAD
+}
+
+.ace-solid-blue .ace_heading,
+.ace-solid-blue .ace_markup.ace_heading,
+.ace-solid-blue .ace_string {
+  color: #D1F1A9
+}
+
+.ace-solid-blue .ace_entity.ace_name.ace_tag,
+.ace-solid-blue .ace_entity.ace_other.ace_attribute-name,
+.ace-solid-blue .ace_meta.ace_tag,
+.ace-solid-blue .ace_string.ace_regexp,
+.ace-solid-blue .ace_variable {
+  color: #FF9DA4
+}
+
+.ace-solid-blue .ace_comment {
+  color: #7285B7
+}
+
+.ace-solid-blue .ace_indent-guide {
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWNgYGBgYJDzqfwPAANXAeNsiA+ZAAAAAElFTkSuQmCC) right repeat-y
+}
+`
+
+ace.define("ace/theme/solid_blue",["require","exports","module","ace/lib/dom"], function(acequire, exports, module) {
+
+exports.isDark = true;
+exports.cssClass = "ace-solid-blue";
+exports.cssText = aceThemeSolidBlueCssText;
+
+var dom = acequire("../lib/dom");
+dom.importCssString(exports.cssText, exports.cssClass);
+
+});

--- a/src/app/editor/styles/theme-solid_light.js
+++ b/src/app/editor/styles/theme-solid_light.js
@@ -29,7 +29,10 @@ var aceThemeSolidLightCssText = `
   color: rgb(191, 191, 191);
 }
 
-.ace-solid-light .ace_storage,
+.ace-solid-light .ace_storage {
+  color: rgb(49, 132, 149);
+}
+
 .ace-solid-light .ace_keyword {
   color: blue;
 }

--- a/src/app/editor/styles/theme-solid_light.js
+++ b/src/app/editor/styles/theme-solid_light.js
@@ -1,0 +1,170 @@
+var styles = require('../../ui/styles-guide/style-guide')()
+
+// based on @see https://raw.githubusercontent.com/thlorenz/brace/v0.8.0/theme/textmate.js
+var aceThemeSolidLightCssText = `
+.ace-solid-light .ace_gutter {
+  background: #f0f0f0;
+  color: #333;
+}
+
+.ace-solid-light .ace_print-margin {
+  width: 1px;
+  background: #e8e8e8;
+}
+
+.ace-solid-light .ace_fold {
+  background-color: #6B72E6;
+}
+
+.ace-solid-light {
+  background-color: #FFFFFF;
+  color: black;
+}
+
+.ace-solid-light .ace_cursor {
+  color: black;
+}
+
+.ace-solid-light .ace_invisible {
+  color: rgb(191, 191, 191);
+}
+
+.ace-solid-light .ace_storage,
+.ace-solid-light .ace_keyword {
+  color: blue;
+}
+
+.ace-solid-light .ace_constant {
+  color: rgb(197, 6, 11);
+}
+
+.ace-solid-light .ace_constant.ace_buildin {
+  color: rgb(88, 72, 246);
+}
+
+.ace-solid-light .ace_constant.ace_language {
+  color: rgb(88, 92, 246);
+}
+
+.ace-solid-light .ace_constant.ace_library {
+  color: rgb(6, 150, 14);
+}
+
+.ace-solid-light .ace_invalid {
+  background-color: rgba(255, 0, 0, 0.1);
+  color: red;
+}
+
+.ace-solid-light .ace_support.ace_function {
+  color: rgb(60, 76, 114);
+}
+
+.ace-solid-light .ace_support.ace_constant {
+  color: rgb(6, 150, 14);
+}
+
+.ace-solid-light .ace_support.ace_type,
+.ace-solid-light .ace_support.ace_class {
+  color: rgb(109, 121, 222);
+}
+
+.ace-solid-light .ace_keyword.ace_operator {
+  color: rgb(104, 118, 135);
+}
+
+.ace-solid-light .ace_string {
+  color: rgb(3, 106, 7);
+}
+
+.ace-solid-light .ace_comment {
+  color: rgb(76, 136, 107);
+}
+
+.ace-solid-light .ace_comment.ace_doc {
+  color: rgb(0, 102, 255);
+}
+
+.ace-solid-light .ace_comment.ace_doc.ace_tag {
+  color: rgb(128, 159, 191);
+}
+
+.ace-solid-light .ace_constant.ace_numeric {
+  color: rgb(0, 0, 205);
+}
+
+.ace-solid-light .ace_variable {
+  color: rgb(49, 132, 149);
+}
+
+.ace-solid-light .ace_xml-pe {
+  color: rgb(104, 104, 91);
+}
+
+.ace-solid-light .ace_entity.ace_name.ace_function {
+  color: #0000A2;
+}
+
+.ace-solid-light .ace_heading {
+  color: rgb(12, 7, 255);
+}
+
+.ace-solid-light .ace_list {
+  color:rgb(185, 6, 144);
+}
+
+.ace-solid-light .ace_meta.ace_tag {
+  color:rgb(0, 22, 142);
+}
+
+.ace-solid-light .ace_string.ace_regex {
+  color: rgb(255, 0, 0)
+}
+
+.ace-solid-light .ace_marker-layer .ace_selection {
+  background: rgb(181, 213, 255);
+}
+
+.ace-solid-light.ace_multiselect .ace_selection.ace_start {
+  box-shadow: 0 0 3px 0px white;
+}
+
+.ace-solid-light .ace_marker-layer .ace_step {
+  background: rgb(252, 255, 0);
+}
+
+.ace-solid-light .ace_marker-layer .ace_stack {
+  background: rgb(164, 229, 101);
+}
+
+.ace-solid-light .ace_marker-layer .ace_bracket {
+  margin: -1px 0 0 -1px;
+  border: 1px solid rgb(192, 192, 192);
+}
+
+.ace-solid-light .ace_marker-layer .ace_active-line {
+  background: rgba(0, 0, 0, 0.07);
+}
+
+.ace-solid-light .ace_gutter-active-line {
+  background-color : #dcdcdc;
+}
+
+.ace-solid-light .ace_marker-layer .ace_selected-word {
+  background: rgb(250, 250, 255);
+  border: 1px solid rgb(200, 200, 250);
+}
+
+.ace-solid-light .ace_indent-guide {
+  background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bLly//BwAmVgd1/w11/gAAAABJRU5ErkJggg==") right repeat-y;
+}
+`
+
+ace.define("ace/theme/solid_light",["require","exports","module","ace/lib/dom"], function(acequire, exports, module) {
+
+exports.isDark = false;
+exports.cssClass = "ace-solid-light";
+exports.cssText = aceThemeSolidLightCssText;
+
+var dom = acequire("../lib/dom");
+dom.importCssString(exports.cssText, exports.cssClass);
+});

--- a/src/app/ui/styles-guide/style-guide.js
+++ b/src/app/ui/styles-guide/style-guide.js
@@ -76,7 +76,7 @@ function styleGuide () {
                           ACE THEME
     ------------------------------------------------------ */
 
-    aceTheme: '',
+    aceTheme: 'solid_light',
 
     /* ------------------------------------------------------
                           BACKGROUND COLORS

--- a/src/app/ui/styles-guide/styleGuideDark.js
+++ b/src/app/ui/styles-guide/styleGuideDark.js
@@ -90,7 +90,7 @@ function styleGuideDark () {
                           ACE THEME
     ------------------------------------------------------ */
 
-    aceTheme: 'tomorrow_night_blue',
+    aceTheme: 'solid_blue',
 
     /* ------------------------------------------------------
                           BACKGROUND COLORS


### PR DESCRIPTION
- Copied https://github.com/thlorenz/brace/blob/v0.8.0/theme/tomorrow_night_blue.js and https://raw.githubusercontent.com/thlorenz/brace/v0.8.0/theme/textmate.js into Remix codebase.
- Changed 1 color as an example.

References: https://github.com/ethereum/remix-ide/issues/1481