### PR TITLE
Update node version for ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   remix-ide:
     docker:
       # specify the version you desire here
-      - image: circleci/node:9.11.2
+      - image: circleci/node:10
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -38,7 +38,7 @@ jobs:
   remix-debugger:
     docker:
       # specify the version you desire here
-      - image: circleci/node:9.11.2
+      - image: circleci/node:10
     
     working_directory: ~/repo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "9"
+  - "10"
 branches:
   only:
   - master


### PR DESCRIPTION
This PR updates Node.js versions for CI build

Details: 
* https://github.com/nodejs/Release#end-of-life-releases
* https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions

![image](https://user-images.githubusercontent.com/25740248/47252831-f1f67580-d485-11e8-8ae0-1525cfd154df.png)
