### PR TITLE
do not allow TreeView .caret_tv element to shrink

### DIFF
--- a/src/app/ui/TreeView.js
+++ b/src/app/ui/TreeView.js
@@ -21,6 +21,7 @@ var css = csjs`
   }
   .caret_tv {
     width: 10px;
+    flex-shrink: 0;
   }
   .label_tv {
     display: flex;


### PR DESCRIPTION
Files in the tree view become unaligned if the tree view window is too small.