### PR TITLE
Shows the balance of deployed contracts in the run tab and automatically updates them.

### DIFF
--- a/src/app/tabs/run-tab.js
+++ b/src/app/tabs/run-tab.js
@@ -203,9 +203,7 @@ function updateDeployedContractBalances (container, self) {
     var contractName = attr.contractName.nodeValue
     self._deps.udapp.getBalanceInEther(address, function (balErr, balance) {
       balance = balance || 0
-      contract.querySelector('.instanceTitleText').innerHTML = `
-        ${contractName} at ${shortAddress} (${context}) (${balance} eth)
-      `
+      contract.querySelector('div[class^="titleText"]').innerHTML = `${contractName} at ${shortAddress} (${context}) (${balance} eth)`
     })
   })
 }
@@ -292,6 +290,7 @@ function makeRecorder (registry, runTabEvent, self) {
             if (noInstancesText.parentNode) { noInstancesText.parentNode.removeChild(noInstancesText) }
             recorder.run(txArray, accounts, options, abis, linkReferences, self._deps.udapp, (abi, address, contractName) => {
               self._deps.udapp.getBalanceInEther(address, (ballErr, balance) => {
+                balance = balance || 0
                 self._view.instanceContainer.appendChild(self._deps.udappUI.renderInstanceFromABI(abi, address, balance, contractName))
               })
             })
@@ -718,7 +717,7 @@ function settings (container, self) {
   }, 10000)
 
   setInterval(() => {
-    updateDeployedContractBalances('.instance', self)
+    updateDeployedContractBalances('#runTabView .instance', self)
   }, 10000)
 
   function newAccount () {

--- a/src/universal-dapp-ui.js
+++ b/src/universal-dapp-ui.js
@@ -28,13 +28,17 @@ UniversalDAppUI.prototype.renderInstance = function (contract, address, balance,
 UniversalDAppUI.prototype.renderInstanceFromABI = function (contractABI, address, balance, contractName) {
   var self = this
   address = (address.slice(0, 2) === '0x' ? '' : '0x') + address.toString('hex')
-  var instance = yo`<div class="instance ${css.instance} ${css.hidesub}" id="instance${address}"></div>`
   var context = self.udapp.context()
 
   var shortAddress = helper.shortenAddress(address)
+  var instance = yo`
+    <div class="instance ${css.instance} ${css.hidesub}" id="instance${address}"
+      address="${address}" shortAddress="${shortAddress}" context="${context}"
+      contractName="${contractName}">
+    </div>`
   var title = yo`
-    <div class="${css.title}" onclick=${toggleClass}>
-    <div class="${css.titleText}"> ${contractName} at ${shortAddress} (${context}) (${balance} eth) </div>
+    <div class="instanceTitle ${css.title}" onclick=${toggleClass}>
+    <div class="instanceTitleText ${css.titleText}"> ${contractName} at ${shortAddress} (${context}) (${balance} eth) </div>
     ${copyToClipboard(() => address)}
   </div>`
 

--- a/src/universal-dapp-ui.js
+++ b/src/universal-dapp-ui.js
@@ -12,20 +12,20 @@ function UniversalDAppUI (udapp, opts = {}) {
   this.udapp = udapp
 }
 
-UniversalDAppUI.prototype.renderInstance = function (contract, address, contractName) {
+UniversalDAppUI.prototype.renderInstance = function (contract, address, balance, contractName) {
   var noInstances = document.querySelector('[class^="noInstancesText"]')
   if (noInstances) {
     noInstances.parentNode.removeChild(noInstances)
   }
   var abi = this.udapp.getABI(contract)
-  return this.renderInstanceFromABI(abi, address, contractName)
+  return this.renderInstanceFromABI(abi, address, balance, contractName)
 }
 
 // TODO this function was named before "appendChild".
 // this will render an instance: contract name, contract address, and all the public functions
 // basically this has to be called for the "atAddress" (line 393) and when a contract creation succeed
 // this returns a DOM element
-UniversalDAppUI.prototype.renderInstanceFromABI = function (contractABI, address, contractName) {
+UniversalDAppUI.prototype.renderInstanceFromABI = function (contractABI, address, balance, contractName) {
   var self = this
   address = (address.slice(0, 2) === '0x' ? '' : '0x') + address.toString('hex')
   var instance = yo`<div class="instance ${css.instance} ${css.hidesub}" id="instance${address}"></div>`
@@ -34,7 +34,7 @@ UniversalDAppUI.prototype.renderInstanceFromABI = function (contractABI, address
   var shortAddress = helper.shortenAddress(address)
   var title = yo`
     <div class="${css.title}" onclick=${toggleClass}>
-    <div class="${css.titleText}"> ${contractName} at ${shortAddress} (${context}) </div>
+    <div class="${css.titleText}"> ${contractName} at ${shortAddress} (${context}) (${balance} eth) </div>
     ${copyToClipboard(() => address)}
   </div>`
 
@@ -61,7 +61,8 @@ UniversalDAppUI.prototype.renderInstanceFromABI = function (contractABI, address
       funABI: fallback,
       address: address,
       contractAbi: contractABI,
-      contractName: contractName
+      contractName: contractName,
+      balance: balance
     }))
   }
 
@@ -74,7 +75,8 @@ UniversalDAppUI.prototype.renderInstanceFromABI = function (contractABI, address
       funABI: funABI,
       address: address,
       contractAbi: contractABI,
-      contractName: contractName
+      contractName: contractName,
+      balance: balance
     }))
   })
 

--- a/src/universal-dapp-ui.js
+++ b/src/universal-dapp-ui.js
@@ -37,8 +37,8 @@ UniversalDAppUI.prototype.renderInstanceFromABI = function (contractABI, address
       contractName="${contractName}">
     </div>`
   var title = yo`
-    <div class="instanceTitle ${css.title}" onclick=${toggleClass}>
-    <div class="instanceTitleText ${css.titleText}"> ${contractName} at ${shortAddress} (${context}) (${balance} eth) </div>
+    <div class="${css.title}" onclick=${toggleClass}>
+    <div class="${css.titleText}"> ${contractName} at ${shortAddress} (${context}) (${balance} eth) </div>
     ${copyToClipboard(() => address)}
   </div>`
 


### PR DESCRIPTION
Closes #596.

Whenever a contract is deployed it lists its balance in eth on the right side.

![balances](https://user-images.githubusercontent.com/22132431/49131475-40daca80-f2d0-11e8-90bf-1677a9d86113.png)


**Changelog**
- Edited `universal-dapp-ui.js` to display the balance in the `TitleText` of the deployed contract.
- Edited both `universal-dapp-ui.js` and `run-tab.js`. The instance div holds all of the contract's information and `run-tab.js` uses it to select it and obtain the necessary information to update the balance.
- The deployed contract balances are updated when a `transactionExecuted` event occurs and every 10 seconds.