### PR TITLE
fix extension matching for current file

### DIFF
--- a/src/app/tabs/compile-tab.js
+++ b/src/app/tabs/compile-tab.js
@@ -476,7 +476,7 @@ module.exports = class CompileTab {
     self._deps.editor.clearAnnotations()
     var currentFile = self._deps.config.get('currentFile')
     if (currentFile) {
-      if (/.(.sol)$/.exec(currentFile)) {
+      if (/\.sol$/.exec(currentFile)) {
         // only compile *.sol file.
         var target = currentFile
         var sources = {}


### PR DESCRIPTION
Current filename matching using regexp `/.(.sol)$/`.
It matches filename such as `xxsol` without extension.
I just change regexp to `/\.sol$/` to match file extension.