### PR TITLE
Record timestamps of contracts passed as arguments

### DIFF
--- a/src/app/tabs/runTab/model/recorder.js
+++ b/src/app/tabs/runTab/model/recorder.js
@@ -54,6 +54,11 @@ class Recorder {
         record.name = payLoad.funAbi.name
         record.inputs = txHelper.serializeInputs(payLoad.funAbi)
         record.type = payLoad.funAbi.type
+        for (var p in record.parameters) {
+          var thisarg = record.parameters[p]
+          var thistimestamp = this.data._createdContracts[thisarg]
+          if (thistimestamp) record.parameters[p] = `created{${thistimestamp}}`
+        }
 
         this.udapp.getAccounts((error, accounts) => {
           if (error) return console.log(error)


### PR DESCRIPTION
When the address of a contract is passed as an argument to a contract function, the recorder records the hard-coded address. On replay, the contracts get new addresses, so the replay fails. 

This change records the timestamp of the contract in place of the contract address. Replays involving a contract address as an argument can then be reliably replayed.