### PR TITLE
Upgraded ethereumjs-util to fix sign message issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .vscode
 build
 node_modules

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "csjs-inject": "^1.0.1",
     "csslint": "^1.0.2",
     "deep-equal": "^1.0.1",
-    "ethereumjs-util": "^5.1.2",
+    "ethereumjs-util": "^6.1.0",
     "execr": "^1.0.1",
     "exorcist": "^0.4.0",
     "fast-async": "6.3.1",

--- a/src/app/tabs/runTab/model/recorder.js
+++ b/src/app/tabs/runTab/model/recorder.js
@@ -31,8 +31,8 @@ class Recorder {
         var record = { value, parameters: payLoad.funArgs }
         if (!to) {
           var abi = payLoad.contractABI
-          var sha3 = ethutil.bufferToHex(ethutil.sha3(abi))
-          record.abi = sha3
+          var keccak = ethutil.bufferToHex(ethutil.keccak(abi))
+          record.abi = keccak
           record.contractName = payLoad.contractName
           record.bytecode = payLoad.contractBytecode
           record.linkReferences = payLoad.linkReferences
@@ -43,9 +43,9 @@ class Recorder {
               }
             }
           }
-          self.data._abis[sha3] = abi
+          self.data._abis[keccak] = abi
 
-          this.data._contractABIReferences[timestamp] = sha3
+          this.data._contractABIReferences[timestamp] = keccak
         } else {
           var creationTimestamp = this.data._createdContracts[to]
           record.to = `created{${creationTimestamp}}`


### PR DESCRIPTION
### Description
Looks like there was some issue while generating signature data in `ethereumjs-util`.
In the below method, even if the `v` value is being passed as `27`, it was retuning the hex string `0x00` which is fixed in the latest version i.e., `6.1.0`

```
ethJSUtil.toRpcSig(v, r, s)
```

Fixes: #1684 