### PR TITLE
fix(@embark-remix): Fix embark-remix plugin

### DIFF
--- a/embark/README.md
+++ b/embark/README.md
@@ -1,0 +1,42 @@
+# embark-remix
+An Embark plugin that allows Remix to connect to a local DApp via [`remixd`](https://github.com/ethereum/remixd). This plugin serves a local copy of Remix IDE from the machine running the plugin or alternatively allows connection from the public [Remix IDE](https://remix.ethereum.org). The URL of the Remix IDE can be specified in the Embark plugin options, specified below.
+
+## Options
+To configure options for the `embark-remix` plugin, modify the `plugins` property of `embark.json` in the DApp.
+
+### How to use default options
+To pass no options to the plugin and use the defaults, simply use an empty object:
+```
+"plugins": {
+  "embark-remix": {}
+}
+```
+This will provide the default options to the plugin (shown below).
+
+### Available options
+The available options for this plugin are below. Default options are shown below. This is equivalent to passing an empty object `{}`.
+```
+"plugins": {
+  "embark-remix": {
+    "readOnly": false,
+    "remixIde": {
+      "protocol": "http",
+      "host": "localhost",
+      "port": 8088
+    }
+  }
+}
+```
+
+
+`readOnly` does not let Remix update the contents on the local filesystem. Default: `false`.
+`remixIde` specifies the URL that the Remix IDE will be served from. If this is a `localhost` URL, the plugin creates a server that is responsible for listening on this URL. Default: `(see above)`.
+
+If it is preferred to connect to the public Remix IDE at https://remix.ethereum.org, set the `remixIde` config to:
+```
+"remixIde": {
+  "protocol": "https",
+  "host": "remix.ethereum.org",
+  "port": false
+}
+```

--- a/embark/README.md
+++ b/embark/README.md
@@ -29,8 +29,11 @@ The available options for this plugin are below. Default options are shown below
 ```
 
 
-`readOnly` does not let Remix update the contents on the local filesystem. Default: `false`.
-`remixIde` specifies the URL that the Remix IDE will be served from. If this is a `localhost` URL, the plugin creates a server that is responsible for listening on this URL. Default: `(see above)`.
+`readOnly` does not let Remix update the contents on the local filesystem. 
+ - Default: `false`
+
+`remixIde` specifies the URL that the Remix IDE will be served from. If this is a `localhost` URL, the plugin creates a server that is responsible for listening on this URL. 
+ - Default: `(see above)`
 
 If it is preferred to connect to the public Remix IDE at https://remix.ethereum.org, set the `remixIde` config to:
 ```

--- a/embark/index.js
+++ b/embark/index.js
@@ -5,9 +5,9 @@ const merge = require('merge')
 const colors = require('colors')
 
 const DEFAULT_OPTIONS = {
-  protocol: "http",
-  host: "localhost",
-  port: "8088"
+  protocol: 'http',
+  host: 'localhost',
+  port: '8088'
 }
 
 module.exports = (embark) => {
@@ -46,7 +46,7 @@ module.exports = (embark) => {
   })
   const killRemixD = sharedFolderRouter.start()
   const kill = () => {
-    if(server) server.close()
+    if (server) server.close()
     embark.logger.info(colors.red('embark-remix stopped'))
     process.exit()
   }
@@ -59,9 +59,8 @@ module.exports = (embark) => {
       process.emit('SIGINT')
     })
   }
-  
+
   process.on('SIGINT', kill) // catch ctrl-c
   process.on('SIGTERM', kill) // catch kill
   process.on('exit', killRemixD)
-
 }

--- a/embark/index.js
+++ b/embark/index.js
@@ -1,8 +1,8 @@
-const httpServer = require('http-server');
-const remixd = require('remixd');
-const path = require('path');
-const merge = require('merge');
-const colors = require('colors');
+const httpServer = require('http-server')
+const remixd = require('remixd')
+const path = require('path')
+const merge = require('merge')
+const colors = require('colors')
 
 const DEFAULT_OPTIONS = {
   protocol: "http",
@@ -12,43 +12,43 @@ const DEFAULT_OPTIONS = {
 
 module.exports = (embark) => {
   // plugin options
-  const readOnly = embark.pluginConfig.readOnly || false;
-  const {protocol, host, port} = merge.recursive(DEFAULT_OPTIONS, embark.pluginConfig.remixIde);
+  const readOnly = embark.pluginConfig.readOnly || false
+  const {protocol, host, port} = merge.recursive(DEFAULT_OPTIONS, embark.pluginConfig.remixIde)
 
   // globals
-  const remixIdeUrl = `${protocol}://${host}` + `${port ? `:${port}` : ''}`;
-  const sharedFolder = path.join(__dirname, '../../');
-  const sharedFolderService = remixd.services.sharedFolder;
-  let server;
+  const remixIdeUrl = `${protocol}://${host}` + `${port ? `:${port}` : ''}`
+  const sharedFolder = path.join(__dirname, '../../')
+  const sharedFolderService = remixd.services.sharedFolder
+  let server
 
   // setup HTTP server
   if (['localhost', '127.0.0.1', '0.0.0.0'].includes(host)) {
     server = httpServer.createServer({
       root: path.join(__dirname, '../../node_modules/remix-ide')
-    });
+    })
     server.listen(port, '127.0.0.1', function () {
-      embark.logger.info('Remix IDE (via embark-remix plugin) available at ' + colors.underline(remixIdeUrl));
-    });
+      embark.logger.info('Remix IDE (via embark-remix plugin) available at ' + colors.underline(remixIdeUrl))
+    })
   } else {
-    embark.logger.info('embark-remix is set to connect to a Remix IDE at ' + colors.underline(remixIdeUrl));
+    embark.logger.info('embark-remix is set to connect to a Remix IDE at ' + colors.underline(remixIdeUrl))
   }
 
   // setup Embark service check
   embark.registerServiceCheck('Remix IDE', (cb) => {
-    return cb({ name: `Remix IDE ${host}:${port}`, status: 'on' });
-  });
+    return cb({ name: `Remix IDE ${host}:${port}`, status: 'on' })
+  })
 
   // setup remixd shared folder service
   const sharedFolderRouter = new remixd.Router(65520, sharedFolderService, { remixIdeUrl }, (webSocket) => {
-    sharedFolderService.setWebSocket(webSocket);
-    sharedFolderService.setupNotifications(sharedFolder);
-    sharedFolderService.sharedFolder(sharedFolder, readOnly);
+    sharedFolderService.setWebSocket(webSocket)
+    sharedFolderService.setupNotifications(sharedFolder)
+    sharedFolderService.sharedFolder(sharedFolder, readOnly)
   })
-  const killRemixD = sharedFolderRouter.start();
+  const killRemixD = sharedFolderRouter.start()
   const kill = () => {
-    if(server) server.close();
-    embark.logger.info(colors.red('embark-remix stopped'));
-    process.exit();
+    if(server) server.close()
+    embark.logger.info(colors.red('embark-remix stopped'))
+    process.exit()
   }
 
   if (process.platform === 'win32') {
@@ -56,12 +56,12 @@ module.exports = (embark) => {
       input: process.stdin,
       output: process.stdout
     }).on('SIGINT', function () {
-      process.emit('SIGINT');
-    });
+      process.emit('SIGINT')
+    })
   }
   
-  process.on('SIGINT', kill); // catch ctrl-c
-  process.on('SIGTERM', kill); // catch kill
-  process.on('exit', killRemixD);
+  process.on('SIGINT', kill) // catch ctrl-c
+  process.on('SIGTERM', kill) // catch kill
+  process.on('exit', killRemixD)
 
 }

--- a/embark/index.js
+++ b/embark/index.js
@@ -1,22 +1,67 @@
-/* global path */
-var httpServer = require('http-server')
-var remixd = require('remixd')
+const httpServer = require('http-server');
+const remixd = require('remixd');
+const path = require('path');
+const merge = require('merge');
+const colors = require('colors');
+
+const DEFAULT_OPTIONS = {
+  protocol: "http",
+  host: "localhost",
+  port: "8088"
+}
 
 module.exports = (embark) => {
-  var server = httpServer.createServer({
-    root: path.join(__dirname, '/node_modules/remix-ide')
-  })
+  // plugin options
+  const readOnly = embark.pluginConfig.readOnly || false;
+  const {protocol, host, port} = merge.recursive(DEFAULT_OPTIONS, embark.pluginConfig.remixIde);
 
+  // globals
+  const remixIdeUrl = `${protocol}://${host}` + `${port ? `:${port}` : ''}`;
+  const sharedFolder = path.join(__dirname, '../../');
+  const sharedFolderService = remixd.services.sharedFolder;
+  let server;
+
+  // setup HTTP server
+  if (['localhost', '127.0.0.1', '0.0.0.0'].includes(host)) {
+    server = httpServer.createServer({
+      root: path.join(__dirname, '../../node_modules/remix-ide')
+    });
+    server.listen(port, '127.0.0.1', function () {
+      embark.logger.info('Remix IDE (via embark-remix plugin) available at ' + colors.underline(remixIdeUrl));
+    });
+  } else {
+    embark.logger.info('embark-remix is set to connect to a Remix IDE at ' + colors.underline(remixIdeUrl));
+  }
+
+  // setup Embark service check
   embark.registerServiceCheck('Remix IDE', (cb) => {
-    return cb({name: 'Remix IDE (localhost:8080)', status: 'on'})
-  })
+    return cb({ name: `Remix IDE ${host}:${port}`, status: 'on' });
+  });
 
-  server.listen(8080, '127.0.0.1', function () {})
-  var router = new remixd.Router(65520, remixd.services.sharedFolder, (webSocket) => {
-    remixd.services.sharedFolder.setWebSocket(webSocket)
-    var sharedFolder = path.join(__dirname, '/../../')
-    remixd.services.sharedFolder.setupNotifications(sharedFolder)
-    remixd.services.sharedFolder.sharedFolder(sharedFolder)
+  // setup remixd shared folder service
+  const sharedFolderRouter = new remixd.Router(65520, sharedFolderService, { remixIdeUrl }, (webSocket) => {
+    sharedFolderService.setWebSocket(webSocket);
+    sharedFolderService.setupNotifications(sharedFolder);
+    sharedFolderService.sharedFolder(sharedFolder, readOnly);
   })
-  router.start()
+  const killRemixD = sharedFolderRouter.start();
+  const kill = () => {
+    if(server) server.close();
+    embark.logger.info(colors.red('embark-remix stopped'));
+    process.exit();
+  }
+
+  if (process.platform === 'win32') {
+    require('readline').createInterface({
+      input: process.stdin,
+      output: process.stdout
+    }).on('SIGINT', function () {
+      process.emit('SIGINT');
+    });
+  }
+  
+  process.on('SIGINT', kill); // catch ctrl-c
+  process.on('SIGTERM', kill); // catch kill
+  process.on('exit', killRemixD);
+
 }


### PR DESCRIPTION
Fix embark-remix plugin to work with the latest version of `remixd`.

Added plugin options to allow for configurable options from `embark.json`.

Added default options. The default options use `http://localhost:8088`, which is a change from `http://localhost:8080`, as this was conflicting with IPFS.

Only start webserver to serve Embark IDE locally if a localhost is specified in the options. If a public URL is specified, it is assumed the Remix IDE is being hosted there and therefore a webserver is not needed. This allows developers to specify connecting to `https://remix.ethereum.org` if desired.