### PR TITLE
Un-mapping brace shortcut Cmd-L which clobbers with browser shortcut 

### DIFF
--- a/src/app/editor/editor.js
+++ b/src/app/editor/editor.js
@@ -99,8 +99,12 @@ class Editor {
     this.editor = ace.edit(el)
     ace.acequire('ace/ext/language_tools')
 
-    // Unmap ctrl-t & ctrl-f
-    this.editor.commands.bindKeys({ 'ctrl-t': null })
+    // Unmap ctrl-t & ctrl-f & ctrl-l & cmd-l
+    this.editor.commands.bindKeys({
+      'ctrl-t': null,
+      'ctrl-L': null,
+      'Command-L': null
+    })
 
     // shortcuts for "Ctrl-"" and "Ctrl+"" to increase/decrease font size of the editor
     this.editor.commands.addCommand({

--- a/src/app/editor/editor.js
+++ b/src/app/editor/editor.js
@@ -99,9 +99,8 @@ class Editor {
     this.editor = ace.edit(el)
     ace.acequire('ace/ext/language_tools')
 
-    // Unmap ctrl-t & ctrl-f & ctrl-l & cmd-l
+    // Unmap ctrl-l & cmd-l
     this.editor.commands.bindKeys({
-      'ctrl-t': null,
       'ctrl-L': null,
       'Command-L': null
     })


### PR DESCRIPTION
Fixes #76 