### PR TITLE
Fix test file generation && don't switch to a File upon workspace loads

### DIFF
--- a/src/app/tabs/test-tab.js
+++ b/src/app/tabs/test-tab.js
@@ -173,7 +173,7 @@ module.exports = class TestTab extends ApiFactory {
           <br/>
           For more details, see
           How to test smart contracts guide in our documentation.
-          <div class="${css.generateTestFile} btn btn-primary m-1" onclick="${this.testTabLogic.generateTestFile(this)}">Generate test file</div>
+          <div class="${css.generateTestFile} btn btn-primary m-1" onclick="${this.testTabLogic.generateTestFile.bind(this.testTabLogic)}">Generate test file</div>
         </div>
         <div class="${css.tests}">          
           <div class="${css.buttons}">

--- a/src/app/ui/landing-page/workspace.js
+++ b/src/app/ui/landing-page/workspace.js
@@ -21,7 +21,6 @@ export const defaultWorkspaces = (appManager) => {
         appManager.ensureActivated('run')
         appManager.ensureActivated('solidityStaticAnalysis')
         appManager.ensureActivated('solidityUnitTesting')
-        globalRegistry.get('filemanager').api.switchFile()
         globalRegistry.get('verticalicon').api.select('solidity')
       }, () => {}),
     new Workspace(
@@ -31,7 +30,6 @@ export const defaultWorkspaces = (appManager) => {
       () => {
         appManager.ensureActivated('vyper')
         appManager.ensureActivated('run')
-        globalRegistry.get('filemanager').api.switchFile()
         globalRegistry.get('verticalicon').api.select('vyper')
       }, () => {}),
     new Workspace('Debugger', 'Debug transactions with remix', false, () => {


### PR DESCRIPTION
this PR:
 - bugfix: test file was generated each time the test module would run.
 - do not autoselect a file after a workspace loads (this is still open discussion cause i m not really sure  that is the way to go) fixes https://github.com/ethereum/remix-ide/issues/1820