### PR TITLE
display current fork name under JavaScript VM

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "remix-ide": "./bin/remix-ide"
   },
   "scripts": {
-    "setupremix": "npm run linkremixdebug && npm run linkremixlib && npm run linkremixsolidity && npm run linkremixsimulator && npm run linkremixtests",
+    "setupremix": "npm run linkremixdebug && npm run linkremixlib && npm run linkremixsolidity && npm run linkremixtests",
     "pullremix": "git clone https://github.com/ethereum/remix",
     "linkremixlib": "cd node_modules && rm -rf remix-lib && ln -s ../../remix/remix-lib remix-lib && cd ..",
     "linkremixsolidity": "cd node_modules && rm -rf remix-solidity && ln -s ../../remix/remix-solidity remix-solidity && cd ..",

--- a/src/app/tabs/compileTab/compilerContainer.js
+++ b/src/app/tabs/compileTab/compilerContainer.js
@@ -135,16 +135,23 @@ class CompilerContainer {
     this._view.version = yo`<span id="version"></span>`
 
     this._view.compilationButton = this.compilationButton()
-
+    this._view.compilerDefaultEvmVersion = yo`
+    <select onchange="${this.onchangeEvmVersion.bind(this)}" class="custom-select" ><option value="petersburg">petersburg</option>
+      <option value="byzantium">byzantium</option>
+      <option value="homestead">homestead</option>
+      <option value="(default)">(default)</option>
+    </select>`
+    this._view.compilerDefaultEvmVersion.add
     this._view.compileContainer = yo`
       <section>
         <!-- Select Compiler Version -->
         <article>
           <header class="navbar navbar-light bg-light input-group mb-3">
-            <div class="input-group-prepend">
+            <div class="input-group-prepend flex-column">
               <label class="input-group-text border-0" for="versionSelector">Compiler</label>
             </div>
             ${this._view.versionSelector}
+            ${this._view.compilerDefaultEvmVersion}
           </header>
           ${this._view.compilationButton}
         </article>
@@ -194,6 +201,14 @@ class CompilerContainer {
     this._updateVersionSelector()
   }
 
+  onchangeEvmVersion (event) {
+    if (event.target.value === '(default)') {
+      this.compileTabLogic.compiler.setToUseDefaultEvmVersion()
+    } else {
+      this.compileTabLogic.compiler.setEvmVersion(event.target.value)
+    }
+  }
+
   _updateVersionSelector () {
     this._view.versionSelector.innerHTML = ''
     this.data.allversions.forEach(build => {
@@ -233,6 +248,12 @@ class CompilerContainer {
   setVersionText (text) {
     this.data.version = text
     if (this._view.version) this._view.version.innerText = text
+    try {
+      const evmVersion = this.compileTabLogic.compiler.defaultEvmVersion() // can throw if no compiler loaded
+      this._view.compilerDefaultEvmVersion.value = evmVersion
+    } catch (e) {
+      this._view.compilerDefaultEvmVersion.value = '(default)'
+    }
   }
 
   fetchAllVersion (callback) {

--- a/src/app/tabs/runTab/model/settings.js
+++ b/src/app/tabs/runTab/model/settings.js
@@ -41,6 +41,10 @@ class Settings {
     return executionContext.getProvider()
   }
 
+  getVM () {
+    return executionContext.vmDescription()
+  }
+
   getAccountBalanceForAddress (address, cb) {
     return this.udapp.getBalanceInEther(address, cb)
   }

--- a/src/app/tabs/runTab/model/settings.js
+++ b/src/app/tabs/runTab/model/settings.js
@@ -49,6 +49,10 @@ class Settings {
     return this.udapp.getBalanceInEther(address, cb)
   }
 
+  updateForkForVM (fork) {
+    executionContext.reloadVMWithFork(fork)
+  }
+
   updateNetwork (cb) {
     this.networkcallid++
     ((callid) => {

--- a/src/app/tabs/runTab/settings.js
+++ b/src/app/tabs/runTab/settings.js
@@ -74,6 +74,22 @@ class SettingsUI {
         </div>
       </div>
     `
+
+    this.vmFork = yo`<div class="${css.crow}">
+    <div class="${css.col1_1}">
+      Fork
+    </div>
+    <div>
+      <select onchange=${(event) => { this.settings.updateForkForVM(event.target.value) }} class="form-control ${css.select}">
+        <option value="petersburg" selected> petersburg
+        </option>
+        <option value="byzantium"> byzantium
+        </option>
+      </select>
+    </div>
+  </div>`
+    this.vmFork.hidden = this.settings.getProvider() !== 'vm'
+
     const networkEl = yo`
     <div class="${css.crow}">
         <div class="${css.col1_1}">
@@ -122,6 +138,7 @@ class SettingsUI {
     const el = yo`
       <div class="${css.settings}">
         ${environmentEl}
+        ${this.vmFork}
         ${networkEl}
         ${accountEl}
         ${gasPriceEl}
@@ -190,10 +207,12 @@ class SettingsUI {
 
   setFinalContext () {
     // set the final context. Cause it is possible that this is not the one we've originaly selected
-    this.selectExEnv.value = this.settings.getProvider()
+    const provider = this.settings.getProvider()
+    this.selectExEnv.value = provider
     this.event.trigger('clearInstance', [])
     this.updateNetwork()
     this.fillAccountsList()
+    this.vmFork.hidden = provider !== 'vm'
   }
 
   newAccount () {

--- a/src/app/tabs/runTab/settings.js
+++ b/src/app/tabs/runTab/settings.js
@@ -250,7 +250,8 @@ class SettingsUI {
         return
       }
       let network = this._deps.networkModule.getNetworkProvider
-      this.netUI.innerHTML = (network() !== 'vm') ? `${name} (${id || '-'}) network` : ''
+      const provider = network()
+      this.netUI.innerHTML = (provider !== 'vm') ? `${name} (${id || '-'}) network` : `fork: ${this.settings.getVM().hardfork}`
     })
   }
 


### PR DESCRIPTION
 - Run: Show fork name under run tab if JavaScript VM
 - Run: Alow to update fork from the run tab if `JavaScript VM` is selected
 - Solidity compiler: Dropdown list showing list of fork and focusing on the default one

linked to https://github.com/ethereum/remix/pull/1186
fix https://github.com/ethereum/remix-ide/issues/1620