### PR TITLE
compile-tab: add evmVersion

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "remix-analyzer": "0.3.6",
     "remix-debug": "0.3.7",
     "remix-lib": "0.4.6",
-    "remix-solidity": "0.3.6",
+    "remix-solidity": "0.3.7",
     "remix-tabs": "1.0.46",
     "remix-tests": "0.1.8",
     "remixd": "0.1.8-alpha.6",

--- a/src/app/tabs/compileTab/compileTab.js
+++ b/src/app/tabs/compileTab/compileTab.js
@@ -25,12 +25,25 @@ class CompileTab {
     this.optimize = this.optimize === 'true'
     this.queryParams.update({ optimize: this.optimize })
     this.compiler.setOptimize(this.optimize)
+
+    this.evmVersion = this.queryParams.get().evmVersion
+    if (this.evmVersion === 'undefined' || this.evmVersion === 'null' || !this.evmVersion) {
+      this.evmVersion = null
+    }
+    this.queryParams.update({ evmVersion: this.evmVersion })
+    this.compiler.setEvmVersion(this.evmVersion)
   }
 
   setOptimize (newOptimizeValue) {
     this.optimize = newOptimizeValue
     this.queryParams.update({ optimize: this.optimize })
     this.compiler.setOptimize(this.optimize)
+  }
+
+  setEvmVersion (newEvmVersion) {
+    this.evmVersion = newEvmVersion
+    this.queryParams.update({ evmVersion: this.evmVersion })
+    this.compiler.setEvmVersion(this.evmVersion)
   }
 
   /**

--- a/src/app/tabs/compileTab/compilerContainer.js
+++ b/src/app/tabs/compileTab/compilerContainer.js
@@ -167,14 +167,23 @@ class CompilerContainer {
       <section>
         <!-- Select Compiler Version -->
         <article>
-          <header class="navbar navbar-light bg-light input-group mb-3">
-            <div class="input-group-prepend">
-              <label class="input-group-text border-0" for="versionSelector">Compiler</label>
+          <header class="navbar navbar-light bg-light">
+            <div class="row w-100 no-gutters mb-2">
+              <div class="col-sm-4">
+                <label class="input-group-text border-0" for="versionSelector">Compiler</label>
+              </div>
+              <div class="col-sm-8">
+                ${this._view.versionSelector}
+              </div>
             </div>
-            ${this._view.versionSelector}
-            <div class="input-group-prepend">
+            <div class="row w-100 no-gutters">
+              <div class="col-sm-4">
+                <label class="input-group-text border-0" for="evmVersionSelector">EVM Version</label>
+              </div>
+              <div class="col-sm-8">
+                ${this._view.evmVersionSelector}
+              </div>
             </div>
-            ${this._view.evmVersionSelector}
           </header>
           ${this._view.compilationButton}
         </article>

--- a/src/app/tabs/compileTab/compilerContainer.js
+++ b/src/app/tabs/compileTab/compilerContainer.js
@@ -136,7 +136,6 @@ class CompilerContainer {
 
     this._view.evmVersionSelector = yo`
       <select onchange="${this.onchangeEvmVersion.bind(this)}" class="custom-select" id="evmVersionSelector">
-        <option disabled selected>EVM Version: default</option>
         <option value="default">compiler default</option>
         <option>petersburg</option>
         <option>constantinople</option>
@@ -154,7 +153,7 @@ class CompilerContainer {
         }
       }
       if (i === s.options.length) { // invalid evmVersion from queryParams
-        s.selectedIndex = 1 // compiler default
+        s.selectedIndex = 0 // compiler default
         this.onchangeEvmVersion()
       } else {
         s.selectedIndex = i
@@ -235,13 +234,7 @@ class CompilerContainer {
       v = null
     }
     this.compileTabLogic.setEvmVersion(v)
-    if (!v) {
-      v = 'default'
-    }
-    const o = yo` <option disabled="disabled" selected="selected">EVM Version: ${v}</option>`
-    s.options[0] = o
-    s.selectedIndex = 0
-    // calling `runCompiler()` here would cause the UI to freeze with the selection drop down menu open
+    this.compile()
   }
 
   onchangeLoadVersion (event) {

--- a/src/app/tabs/compileTab/compilerContainer.js
+++ b/src/app/tabs/compileTab/compilerContainer.js
@@ -134,6 +134,33 @@ class CompilerContainer {
       </select>`
     this._view.version = yo`<span id="version"></span>`
 
+    this._view.evmVersionSelector = yo`
+      <select onchange="${this.onchangeEvmVersion.bind(this)}" class="custom-select" id="evmVersionSelector">
+        <option disabled selected>EVM Version: default</option>
+        <option value="default">compiler default</option>
+        <option>petersburg</option>
+        <option>constantinople</option>
+        <option>byzantium</option>
+        <option>spuriousDragon</option>
+        <option>tangerineWhistle</option>
+        <option>homestead</option>
+      </select>`
+    if (this.compileTabLogic.evmVersion) {
+      let s = this._view.evmVersionSelector
+      let i
+      for (i = 0; i < s.options.length; i++) {
+        if (s.options[i].value === this.compileTabLogic.evmVersion) {
+          break
+        }
+      }
+      if (i === s.options.length) { // invalid evmVersion from queryParams
+        s.selectedIndex = 1 // compiler default
+        this.onchangeEvmVersion()
+      } else {
+        s.selectedIndex = i
+      }
+    }
+
     this._view.compilationButton = this.compilationButton()
 
     this._view.compileContainer = yo`
@@ -145,6 +172,9 @@ class CompilerContainer {
               <label class="input-group-text border-0" for="versionSelector">Compiler</label>
             </div>
             ${this._view.versionSelector}
+            <div class="input-group-prepend">
+            </div>
+            ${this._view.evmVersionSelector}
           </header>
           ${this._view.compilationButton}
         </article>
@@ -187,6 +217,22 @@ class CompilerContainer {
   onchangeOptimize () {
     this.compileTabLogic.setOptimize(!!this._view.optimize.checked)
     this.compileTabLogic.runCompiler()
+  }
+
+  onchangeEvmVersion (_) {
+    let s = this._view.evmVersionSelector
+    let v = s.value
+    if (v === 'default') {
+      v = null
+    }
+    this.compileTabLogic.setEvmVersion(v)
+    if (!v) {
+      v = 'default'
+    }
+    const o = yo` <option disabled="disabled" selected="selected">EVM Version: ${v}</option>`
+    s.options[0] = o
+    s.selectedIndex = 0
+    // calling `runCompiler()` here would cause the UI to freeze with the selection drop down menu open
   }
 
   onchangeLoadVersion (event) {


### PR DESCRIPTION
Specifying a specific EVM version for `solc` to target
is useful when targetting older private chains deployments
with the latest compiler.

This work in progress patch adds an "EVM Version" drop down menu
in the compiler tab.

This patch depends on https://github.com/ethereum/remix/pull/1193
in `remix-solidity` to pass down the `evmVersion` option.