### PR TITLE
Fix 'ballot' and 'compiling' browser tests under nightwatch_local

### DIFF
--- a/src/app/tabs/runTab/settings.js
+++ b/src/app/tabs/runTab/settings.js
@@ -97,7 +97,7 @@ class SettingsUI {
         <div class=${css.account}>
           <select name="txorigin" class="form-control ${css.select}" id="txorigin"></select>
           ${copyToClipboard(() => document.querySelector('#runTabView #txorigin').value)}
-          <i id="remixRunSignMsg" class="fas fa-edit ${css.icon}" aria-hiden="true" onclick=${this.signMessage.bind(this)} title="Sign a message using this account key"></i>
+          <i id="remixRunSignMsg" class="fas fa-edit ${css.icon}" aria-hidden="true" onclick=${this.signMessage.bind(this)} title="Sign a message using this account key"></i>
         </div>
       </div>
     `

--- a/test-browser/helpers/contracts.js
+++ b/test-browser/helpers/contracts.js
@@ -172,7 +172,9 @@ function scrollInto (target) {
 function signMsg (browser, msg, cb) {
   let hash, signature
   browser
+    .waitForElementPresent('i[id="remixRunSignMsg"]')
     .click('i[id="remixRunSignMsg"]')
+    .waitForElementPresent('textarea[id="prompt_text"]')
     .setValue('textarea[id="prompt_text"]', msg, () => {
       browser.modalFooterOKClick().perform(
         (client, done) => {

--- a/test-browser/tests/compiling.js
+++ b/test-browser/tests/compiling.js
@@ -160,8 +160,8 @@ function testInputValues (browser, callback) {
 
 var sources = [
   {'browser/Untitled.sol': {content: `
-      contract TestContract { function f() public returns (uint) { return 8; } 
-      function g() public returns (uint, string memory, bool, uint) {  
+      contract TestContract { function f() public returns (uint) { return 8; }
+      function g() public returns (uint, string memory, bool, uint) {
         uint payment = 345;
         bool payed = true;
         string memory comment = "comment_comment_";
@@ -176,7 +176,7 @@ var sources = [
         _i = -345;
         _a = msg.sender;
     }
-    
+
     function retunValues2 () public returns (byte _b, bytes2 _b2, bytes3 _b3, bytes memory _blit, bytes5 _b5, bytes6 _b6, string memory _str, bytes7 _b7, bytes22 _b22, bytes32 _b32)  {
         _b = 0x12;
         _b2 = 0x1223;
@@ -188,7 +188,7 @@ var sources = [
         _blit = hex"123498";
         _str = "this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string _ this is a long string";
     }
-    
+
     function retunValues3 () public returns (ActionChoices _en, int[5][] memory _a1)  {
        _en = ActionChoices.GoStraight;
        int[5][] memory a = new int[5][](3);


### PR DESCRIPTION
The `testSignature()` browser test in `generalTests.js` would
occasionally fail due to not obtaining the correct `hash` and
`signature` values from the browser, resulting in:
```
✖ generalTests
   - Simple Contract (40.954s)
   Failed [equal]: ('' == '0: address: 0xCA35b7d915458EF540aDe6068dFe2F44E8fa733c')  - expected "0: address: 0xCA35b7d915458EF540aDe6068dFe2F44E8fa733c" but got: ""
       at Object.<anonymous> (/home/scottt/work/remix-0.8/remix-ide/test-browser/helpers/contracts.js:129:22)
```
failures.

This patch fixes it by waiting for the DOM elements with
`waitForElementPresent` which implicitly retries and obtaining
the correct contract instance address instead of hard coding it.
