### PR TITLE
Fix modal dialog callback being called multiple times

### DIFF
--- a/src/app/tabs/runTab/settings.js
+++ b/src/app/tabs/runTab/settings.js
@@ -273,11 +273,12 @@ class SettingsUI {
       var account = $txOrigin.selectedOptions[0].value
 
       var promptCb = (passphrase) => {
-        modalDialogCustom.promptMulti(signMessageDialog, (message) => {
+        const modal = modalDialogCustom.promptMulti(signMessageDialog, (message) => {
           this.settings.signMessage(message, account, passphrase, (err, msgHash, signedData) => {
             if (err) {
               return addTooltip(err)
             }
+            modal.hide()
             modalDialogCustom.alert(yo`
               <div>
                 <b>hash:</b><br>

--- a/src/app/ui/modal-dialog-custom.js
+++ b/src/app/ui/modal-dialog-custom.js
@@ -4,13 +4,13 @@ var css = require('./styles/modal-dialog-custom-styles')
 
 module.exports = {
   alert: function (text) {
-    modal('', yo`<div>${text}</div>`, null, { label: null })
+    return modal('', yo`<div>${text}</div>`, null, { label: null })
   },
   prompt: function (title, text, inputValue, ok, cancel, focus) {
-    prompt(title, text, false, inputValue, ok, cancel, focus)
+    return prompt(title, text, false, inputValue, ok, cancel, focus)
   },
   promptPassphrase: function (title, text, inputValue, ok, cancel) {
-    prompt(title, text, true, inputValue, ok, cancel)
+    return prompt(title, text, true, inputValue, ok, cancel)
   },
   promptPassphraseCreation: function (ok, cancel) {
     var text = 'Please provide a Passphrase for the account creation'
@@ -20,7 +20,7 @@ module.exports = {
       <br>
       <input id="prompt2" type="password" name='prompt_text' class="${css['prompt_text']}" >
     </div>`
-    modal(null, yo`<div>${text}<div>${input}</div></div>`,
+    return modal(null, yo`<div>${text}<div>${input}</div></div>`,
       {
         fn: () => {
           if (typeof ok === 'function') {
@@ -42,7 +42,7 @@ module.exports = {
   promptMulti: function ({ title, text, inputValue }, ok, cancel) {
     if (!inputValue) inputValue = ''
     var input = yo`<textarea id="prompt_text" class=${css.prompt_text} rows="4" cols="50"></textarea>`
-    modal(title, yo`<div>${text}<div>${input}</div></div>`,
+    return modal(title, yo`<div>${text}<div>${input}</div></div>`,
       {
         fn: () => { if (typeof ok === 'function') ok(document.getElementById('prompt_text').value) }
       },
@@ -52,7 +52,7 @@ module.exports = {
     )
   },
   confirm: function (title, text, ok, cancel) {
-    modal(title, yo`<div>${text}</div>`,
+    return modal(title, yo`<div>${text}</div>`,
       {
         fn: () => { if (typeof ok === 'function') ok() }
       },

--- a/src/app/ui/modaldialog.js
+++ b/src/app/ui/modaldialog.js
@@ -77,7 +77,8 @@ module.exports = (title, content, ok, cancel, focusSelector, opts) => {
   }
 
   function hide () {
-    if (container) container.style.display = 'none'
+    if (!container) return
+    container.style.display = 'none'
     if (container.parentElement) container.parentElement.removeChild(container)
     container = null
   }
@@ -119,7 +120,7 @@ module.exports = (title, content, ok, cancel, focusSelector, opts) => {
       }
     })
   }
-  return { container, okListener, cancelListener }
+  return { container, okListener, cancelListener, hide }
 }
 
 function html (opts) {

--- a/src/app/ui/modaldialog.js
+++ b/src/app/ui/modaldialog.js
@@ -49,18 +49,14 @@ module.exports = (title, content, ok, cancel, focusSelector, opts) => {
 
   function okListener () {
     removeEventListener()
-    hide()
     if (ok && ok.fn && agreed) ok.fn()
+    hide()
   }
 
   function cancelListener () {
     removeEventListener()
-    hide()
     if (cancel && cancel.fn) cancel.fn()
-    if (container) {
-      container.class = `modal`
-      container = null
-    }
+    hide()
   }
 
   function modalKeyEvent (e) {
@@ -83,6 +79,7 @@ module.exports = (title, content, ok, cancel, focusSelector, opts) => {
   function hide () {
     if (container) container.style.display = 'none'
     if (container.parentElement) container.parentElement.removeChild(container)
+    container = null
   }
 
   function show () {

--- a/src/app/ui/modaldialog.js
+++ b/src/app/ui/modaldialog.js
@@ -82,6 +82,7 @@ module.exports = (title, content, ok, cancel, focusSelector, opts) => {
 
   function hide () {
     if (container) container.style.display = 'none'
+    if (container.parentElement) container.parentElement.removeChild(container)
   }
 
   function show () {

--- a/test-browser/commands/addFile.js
+++ b/test-browser/commands/addFile.js
@@ -14,6 +14,7 @@ class AddFile extends EventEmitter {
 
 function addFile (browser, name, content, done) {
   browser.clickLaunchIcon('udapp').clickLaunchIcon('fileExplorers').click('.newFile')
+      .waitForElementVisible('#modal-dialog')
       .perform((client, done) => {
         browser.execute(function (fileName) {
           if (fileName !== 'Untitled.sol') {

--- a/test-browser/commands/verifyContracts.js
+++ b/test-browser/commands/verifyContracts.js
@@ -14,7 +14,7 @@ class VerifyContracts extends EventEmitter {
 
 function getCompiledContracts (browser, callback) {
   browser.clickLaunchIcon('solidity').execute(function () {
-    var contracts = document.querySelectorAll('#compileTabView select option')
+    var contracts = document.querySelectorAll('#compileTabView select#compiledContracts option')
     if (!contracts) {
       return null
     } else {
@@ -33,7 +33,7 @@ function verifyContracts (browser, compiledContractNames, callback) {
   getCompiledContracts(browser, (result) => {
     if (result.value) {
       for (var contract in compiledContractNames) {
-        console.log(' - ' + compiledContractNames[contract])
+        console.log(' - ' + compiledContractNames[contract], result.value)
         if (result.value.indexOf(compiledContractNames[contract]) === -1) {
           browser.assert.fail('compiled contract ' + compiledContractNames + ' not found', 'info about error', '')
           browser.end()


### PR DESCRIPTION
When the modal closes, we need to remove the DOM element. 
If not, we create a new EventListener associated with the modal each time the modal shows up.
And basically when the user `Cancel` the modal, all the previous callback where the modal was used get called.
That's pretty critical