### PR TITLE
this should fix long strings that overflow limits

### DIFF
--- a/src/app/ui/TreeView.js
+++ b/src/app/ui/TreeView.js
@@ -26,6 +26,9 @@ var css = csjs`
   .label_tv {
     align-items: center;
   }
+  .label_tv>span {
+    word-break: break-all;
+  }
 `
 
 var EventManager = require('../../lib/events')


### PR DESCRIPTION
When we have one long string, as result of returned data array of addresses for example, this text its not visible. 
![remix issue ](https://user-images.githubusercontent.com/12281088/61072954-45419700-a40c-11e9-83d8-6a287a3ad0d0.png)

With this commit: 

![remix issue fixed](https://user-images.githubusercontent.com/12281088/61072959-483c8780-a40c-11e9-8853-13c1388027c6.png)
