### PR TITLE
Fix links to new documentation site

### DIFF
--- a/docs/create_deploy.md
+++ b/docs/create_deploy.md
@@ -2,7 +2,7 @@ Creating and Deploying a Contract
 ================================
 
 There are 3 type of environments Remix can be plugged to:
-`Javascript VM`, `Injected provider`, or `Web3 provider`. (for details see [Running transactions](http://remix.readthedocs.io/en/latest/run_tab.html))
+`Javascript VM`, `Injected provider`, or `Web3 provider`. (for details see [Running transactions](https://remix-ide.readthedocs.io/en/latest/run.html))
 
 Both `Web3 provider` and `Injected provider` require the use of an
 external tool.

--- a/docs/locations.md
+++ b/docs/locations.md
@@ -6,5 +6,5 @@ So if you've found the documentation to Remix but don't know where to find Remix
 - An online version is available at [https://remix.ethereum.org](https://remix.ethereum.org). This version is stable and is updated at almost every release.
 - An alpha online version is available at [https://remix-alpha.ethereum.org](https://remix-alpha.ethereum.org). This is not a stable version.
 - npm `remix-ide` package `npm install remix-ide -g`. `remix-ide` create a new instance of `Remix IDE` available at [http://127.0.0.1:8080](http://127.0.0.1:8080) and make the current folder available to Remix IDE by automatically starting `remixd`.
-see [Connection to `remixd`](http://remix.readthedocs.io/en/latest/tutorial_remixd_filesystem.html) for more information about sharing local file with `Remix IDE`.
+see [Connection to `remixd`](https://remix-ide.readthedocs.io/en/latest/remixd.html) for more information about sharing local file with `Remix IDE`.
 - Github release: [https://github.com/ethereum/remix-ide/releases](https://github.com/ethereum/remix-ide/releases) . The source code is packaged at every release but still need to be built using `npm run build`.

--- a/team-best-practices.md
+++ b/team-best-practices.md
@@ -19,7 +19,7 @@ Related links:
  - Remix-lib NPM module: https://www.npmjs.com/package/remix-lib
  - Remix-solidity NPM module: https://www.npmjs.com/package/remix-solidity
  - Remix-debug NPM module: https://www.npmjs.com/package/remix-debug
- - Remix documentation: http://remix.readthedocs.io/en/latest/
+ - Remix documentation: http://remix-ide.readthedocs.io/en/latest/
  - General gitter channel: https://gitter.im/ethereum/remix
  - Dev gitter channel: https://gitter.im/ethereum/remix-dev
  - Huboard (task management tool): https://huboard.com/ethereum/remix-ide


### PR DESCRIPTION
Changes instances of `remix.readthedocs` to `remix-ide.readthedocs`with the correct links

I also changed them in `assets/js/0.7.7/app.js`, however the diff is showing the whole file was changed? I don't think I did this correctly.