### PR TITLE
Add documentation link to new "Flattener Plugin"

### DIFF
--- a/src/remixAppManager.js
+++ b/src/remixAppManager.js
@@ -234,6 +234,7 @@ export class RemixAppManager extends PluginEngine {
       version: '0.1.0',
       url: 'https://remix-flattener.netlify.com',
       description: 'Flattens compiled smart contracts',
+      documentation: 'https://github.com/Destiner/remix-flattener',
       icon: 'https://remix-flattener.netlify.com/logo.svg',
       location: 'sidePanel'
     }


### PR DESCRIPTION
@Destiner thanks for making this! Just adding this so its easier for people to contribute, post issues, etc. It makes a little "book" icon in the plugin to link to the repo.