### PR TITLE
firefox restriction removed

### DIFF
--- a/src/app/tabs/compileTab/compilerContainer.js
+++ b/src/app/tabs/compileTab/compilerContainer.js
@@ -319,8 +319,8 @@ class CompilerContainer {
       }
       url = `${this.data.baseurl}/${this.data.selectedVersion}`
     }
-    const isFirefox = typeof InstallTrigger !== 'undefined'
-    if (document.location.protocol !== 'file:' && Worker !== undefined && isFirefox) {
+    // Check if browser is compatible with web worker
+    if (document.location.protocol !== 'file:' && Worker !== undefined) {
       // Workers cannot load js on "file:"-URLs and we get a
       // "Uncaught RangeError: Maximum call stack size exceeded" error on Chromium,
       // resort to non-worker version in that case.

--- a/src/app/tabs/compileTab/compilerContainer.js
+++ b/src/app/tabs/compileTab/compilerContainer.js
@@ -320,7 +320,7 @@ class CompilerContainer {
       url = `${this.data.baseurl}/${this.data.selectedVersion}`
     }
     // Check if browser is compatible with web worker
-    if (document.location.protocol !== 'file:' && Worker !== undefined) {
+    if (this.browserSupportWorker) {
       // Workers cannot load js on "file:"-URLs and we get a
       // "Uncaught RangeError: Maximum call stack size exceeded" error on Chromium,
       // resort to non-worker version in that case.
@@ -372,6 +372,10 @@ class CompilerContainer {
     if (!this.config.get('autoCompile')) return
     if (this.data.compileTimeout) window.clearTimeout(this.data.compileTimeout)
     this.data.compileTimeout = window.setTimeout(() => this.compileIfAutoCompileOn(), this.data.timeout)
+  }
+
+  browserSupportWorker () {
+    return document.location.protocol !== 'file:' && Worker !== undefined
   }
 
 }

--- a/test-browser/commands/verifyContracts.js
+++ b/test-browser/commands/verifyContracts.js
@@ -13,7 +13,10 @@ class VerifyContracts extends EventEmitter {
 }
 
 function getCompiledContracts (browser, callback) {
-  browser.clickLaunchIcon('solidity').execute(function () {
+  browser
+  .clickLaunchIcon('solidity')
+  .waitForElementPresent('#compileTabView select#compiledContracts option')
+  .execute(function () {
     var contracts = document.querySelectorAll('#compileTabView select#compiledContracts option')
     if (!contracts) {
       return null


### PR DESCRIPTION
Now asynchronous loading of solidity compiler using web worker works for each browser which is compatible with web worker.

Related to https://github.com/ethereum/remix/issues/1239