### PR TITLE
Fixes bug in network.getEndpoint()

### DIFF
--- a/src/app/tabs/network-module.js
+++ b/src/app/tabs/network-module.js
@@ -55,7 +55,7 @@ export class NetworkModule extends Plugin {
     if (provider !== 'web3') {
       throw new Error('no endpoint: current provider is either injected or vm')
     }
-    return provider.web3().currentProvider.host
+    return executionContext.web3().currentProvider.host
   }
 
   /** Add a custom network to the list of available networks */


### PR DESCRIPTION
`provider` here is just a string, it was supposed to be `executionContext.web3()`. Tested locally and that fixes the call