### PR TITLE
use white-space:pre-wrap for spaces make effect

### DIFF
--- a/src/app/tabs/debugger/debuggerUI/vmDebugger/utils/SolidityTypeFormatter.js
+++ b/src/app/tabs/debugger/debuggerUI/vmDebugger/utils/SolidityTypeFormatter.js
@@ -12,7 +12,7 @@ function formatSelf (key, data) {
   if (data.type === 'string') {
     data.self = JSON.stringify(data.self)
   }
-  return yo`<label style=${keyStyle}>${key}: <label style=${style}>${data.self}</label><label style='font-style:italic'> ${data.isProperty || !data.type ? '' : ' ' + data.type}</label></label>`
+  return yo `<label style='${keyStyle};white-space:pre-wrap;'> ${' ' + key}:<label style=${style}>${' ' + data.self}</label><label style='font-style:italic'> ${data.isProperty || !data.type ? '' : ' ' + data.type}</label></label>`
 }
 
 function extractData (item, parent, key) {


### PR DESCRIPTION
The white spaces are not rendered: 
The normal behavior for the display of whitespaces is to compress them into a single one, which is then displayed.

There are two exceptions from that:

The pre tag, which keeps the whitespaces as entered.
Setting the CSS property white-space: pre; (respectively pre-wrap or pre-line)

Ex: 
![image](https://user-images.githubusercontent.com/12281088/66775334-9786ce00-eebb-11e9-8832-abe7e2d38005.png)

in the code we can add a simple style for childs with white-space style.

Result in to this render: 

![image](https://user-images.githubusercontent.com/12281088/66775459-ec2a4900-eebb-11e9-90e5-8389d10bcf45.png)
