### PR TITLE
Updates quorum urls

### DIFF
--- a/src/remixAppManager.js
+++ b/src/remixAppManager.js
@@ -208,10 +208,10 @@ export class RemixAppManager extends PluginEngine {
       description: 'Deploy and interact with private contracts on a Quorum network.',
       events: [],
       methods: [],
-      url: 'https://jpmorganchase.github.io/qr/',
-      icon: 'https://jpmorganchase.github.io/qr/tab_icon.png',
-      documentation: 'https://docs.goquorum.com/',
-      version: '0.1.0-beta',
+      url: '//remix-plugin.goquorum.com/',
+      icon: '//remix-plugin.goquorum.com/tab_icon.png',
+      documentation: 'https://docs.goquorum.com/en/latest/RemixPlugin/Overview/',
+      version: '0.1.4-beta',
       location: 'sidePanel'
     }
     const res = await fetch(this.pluginsDirectory)


### PR DESCRIPTION
Due to the Quorum plugin iframe being loaded from an https site all the time, even if they were using http remix, users were not able to connect to a non-localhost http node.

So we moved the Quorum plugin from being hosted on github pages to a subdomain of our official site. This allows us to serve the page as both http and https.

We also changed the url to be protocol relative ("//url" rather than "https://url"), so that when the iframe element is loaded, it will use the scheme of the top-level page. So if you load http remix, you'll get the http quorum plugin. This should make the plugin accessible to more users, especially those running development environments that are not ssl protected.