### PR TITLE
Add rust ace mode to editor

### DIFF
--- a/src/app/editor/editor.js
+++ b/src/app/editor/editor.js
@@ -19,6 +19,7 @@ require('ace-mode-zokrates')
 require('brace/mode/javascript')
 require('brace/mode/python')
 require('brace/mode/json')
+require('brace/mode/rust')
 require('brace/theme/chaos')
 require('brace/theme/chrome')
 
@@ -85,7 +86,8 @@ class Editor extends Plugin {
       zok: 'ace/mode/zokrates',
       txt: 'ace/mode/text',
       json: 'ace/mode/json',
-      abi: 'ace/mode/json'
+      abi: 'ace/mode/json',
+      rs: 'ace/mode/rust'
     }
 
     // Editor Setup


### PR DESCRIPTION
As our plugin is currently in the last stage of alpha development, we would like to have syntax highlighting for Rust language in editor as our plugin builds smart contracts written in Rust in its core process. This pull request adds official rust ace mode implementation from brace package in editor component.