### PR TITLE
Load plugins from parameters

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,3 @@
-/* global localStorage */
 'use strict'
 
 var isElectron = require('is-electron')

--- a/src/app.js
+++ b/src/app.js
@@ -208,7 +208,7 @@ Please make a backup of your contracts and start using http://remix.ethereum.org
 
   // APP_MANAGER
   const appManager = new RemixAppManager({})
-  const workspace = JSON.parse(localStorage.getItem('workspace'))
+  const workspace = appManager.pluginLoader.get()
 
   // SERVICES
   // ----------------- import content servive ----------------------------

--- a/src/remixAppManager.js
+++ b/src/remixAppManager.js
@@ -240,6 +240,7 @@ class PluginLoader {
   get currentLoader () {
     return this.loaders[this.current]
   }
+
   constructor () {
     const queryParams = new QueryParams()
     this.donotAutoReload = ['remixd'] // that would be a bad practice to force loading some plugins at page load.
@@ -250,15 +251,13 @@ class PluginLoader {
           localStorage.setItem('workspace', JSON.stringify(actives))
         }
       },
-      get: () => {
-        return JSON.parse(localStorage.getItem('workspace'))
-      }
+      get: () => { return JSON.parse(localStorage.getItem('workspace')) }
     }
 
     this.loaders['queryParams'] = {
       set: () => {},
       get: () => {
-        let plugins = queryParams.get()['plugins']
+        const { plugins } = queryParams.get()
         if (!plugins) return []
         return plugins.split(',')
       }
@@ -268,10 +267,10 @@ class PluginLoader {
   }
 
   set (plugin, actives) {
-    this.currentLoader().set(plugin, actives)
+    this.currentLoader.set(plugin, actives)
   }
 
   get () {
-    return this.currentLoader().get()
+    return this.currentLoader.get()
   }
 }

--- a/src/remixAppManager.js
+++ b/src/remixAppManager.js
@@ -232,6 +232,10 @@ export class RemixAppManager extends PluginEngine {
   }
 }
 
+/** @class Reference loaders.
+ *  A loader is a get,set based object which load a workspace from a defined sources.
+ *  (localStorage, queryParams)
+ **/
 class PluginLoader {
   constructor () {
     const queryParams = new QueryParams()

--- a/src/remixAppManager.js
+++ b/src/remixAppManager.js
@@ -2,6 +2,7 @@
 import { PluginEngine, IframePlugin } from '@remixproject/engine'
 import { EventEmitter } from 'events'
 import { PermissionHandler } from './app/ui/persmission-handler'
+import QueryParams from './lib/query-params'
 
 const requiredModules = [ // services + layout views + system views
   'compilerArtefacts', 'compilerMetadata', 'contextualListener', 'editor', 'offsetToLineColumnConverter', 'network', 'theme', 'fileManager', 'contentImport',
@@ -19,15 +20,13 @@ export class RemixAppManager extends PluginEngine {
   constructor (plugins) {
     super(plugins, settings)
     this.event = new EventEmitter()
-    this.donotAutoReload = ['remixd'] // that would be a bad practice to force loading some plugins at page load.
     this.registered = {}
     this.pluginsDirectory = 'https://raw.githubusercontent.com/ethereum/remix-plugins-directory/master/build/profile.json'
+    this.pluginLoader = new PluginLoader()
   }
 
   onActivated (plugin) {
-    if (!this.donotAutoReload.includes(plugin.name)) {
-      localStorage.setItem('workspace', JSON.stringify(this.actives))
-    }
+    this.pluginLoader.set(plugin, this.actives)
     this.event.emit('activate', plugin.name)
   }
 
@@ -46,7 +45,7 @@ export class RemixAppManager extends PluginEngine {
   }
 
   onDeactivated (plugin) {
-    localStorage.setItem('workspace', JSON.stringify(this.actives))
+    this.pluginLoader.set(plugin, this.actives)
     this.event.emit('deactivate', plugin.name)
   }
 
@@ -230,5 +229,42 @@ export class RemixAppManager extends PluginEngine {
       new IframePlugin(quorum),
       ...plugins.map(plugin => new IframePlugin(plugin))
     ]
+  }
+}
+
+class PluginLoader {
+  constructor () {
+    const queryParams = new QueryParams()
+    this.donotAutoReload = ['remixd'] // that would be a bad practice to force loading some plugins at page load.
+    this.loaders = {}
+    this.loaders['localStorage'] = {
+      set: (plugin, actives) => {
+        if (!this.donotAutoReload.includes(plugin.name)) {
+          localStorage.setItem('workspace', JSON.stringify(actives))
+        }
+      },
+      get: () => {
+        return JSON.parse(localStorage.getItem('workspace'))
+      }
+    }
+
+    this.loaders['queryParams'] = {
+      set: () => {},
+      get: () => {
+        let plugins = queryParams.get()['plugins']
+        if (!plugins) return []
+        return plugins.split(',')
+      }
+    }
+
+    this.current = queryParams.get()['plugins'] ? 'queryParams' : 'localStorage'
+  }
+
+  set (plugin, actives) {
+    this.loaders[this.current].set(plugin, actives)
+  }
+
+  get () {
+    return this.loaders[this.current].get()
   }
 }

--- a/src/remixAppManager.js
+++ b/src/remixAppManager.js
@@ -237,6 +237,9 @@ export class RemixAppManager extends PluginEngine {
  *  (localStorage, queryParams)
  **/
 class PluginLoader {
+  get currentLoader () {
+    return this.loaders[this.current]
+  }
   constructor () {
     const queryParams = new QueryParams()
     this.donotAutoReload = ['remixd'] // that would be a bad practice to force loading some plugins at page load.
@@ -265,10 +268,10 @@ class PluginLoader {
   }
 
   set (plugin, actives) {
-    this.loaders[this.current].set(plugin, actives)
+    this.currentLoader().set(plugin, actives)
   }
 
   get () {
-    return this.loaders[this.current].get()
+    return this.currentLoader().get()
   }
 }

--- a/test-browser/helpers/init.js
+++ b/test-browser/helpers/init.js
@@ -1,14 +1,16 @@
-module.exports = function (browser, callback) {
+module.exports = function (browser, callback, url, preloadPlugins = true) {
   browser
-    .url('http://127.0.0.1:8080')
+    .url(url || 'http://127.0.0.1:8080')
     .injectScript('test-browser/helpers/applytestmode.js', function () {
       browser.resizeWindow(2560, 1440, () => {
-        initModules(browser, () => {
-          browser.clickLaunchIcon('solidity').click('#autoCompile')
-          .perform(function () {
-            callback()
+        if (preloadPlugins) {
+          initModules(browser, () => {
+            browser.clickLaunchIcon('solidity').click('#autoCompile')
+            .perform(function () {
+              callback()
+            })
           })
-        })
+        } else callback()
       })
     })
 }

--- a/test-browser/tests/workspace.js
+++ b/test-browser/tests/workspace.js
@@ -1,6 +1,6 @@
 'use strict'
-var init = require('../helpers/init')
-var sauce = require('./sauce')
+const init = require('../helpers/init')
+const sauce = require('./sauce')
 
 module.exports = {
   before: function (browser, done) {

--- a/test-browser/tests/workspace.js
+++ b/test-browser/tests/workspace.js
@@ -1,0 +1,17 @@
+'use strict'
+var init = require('../helpers/init')
+var sauce = require('./sauce')
+
+module.exports = {
+  before: function (browser, done) {
+    init(browser, done, 'http://127.0.0.1:8080?plugins=solidity,udapp', false)
+  },
+  'CheckSolidityActivatedAndUDapp': function (browser) {
+    browser
+    .waitForElementVisible('#icon-panel', 10000)
+    .clickLaunchIcon('solidity')
+    .clickLaunchIcon('udapp')
+    .end()
+  },
+  tearDown: sauce
+}


### PR DESCRIPTION
This PR:
 - refactor the way plugins are loaded at page load.
 - load from query param if provided, from local storage if not.
