### PR TITLE
Script Execution - Async/Await support

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -332,6 +332,7 @@ Please make a backup of your contracts and start using http://remix.ethereum.org
   engine.register([
     menuicons,
     landingPage,
+    hiddenPanel,
     sidePanel,
     pluginManagerComponent,
     filePanel,
@@ -384,7 +385,7 @@ Please make a backup of your contracts and start using http://remix.ethereum.org
 
   await appManager.activatePlugin(['contentImport', 'theme', 'editor', 'fileManager', 'compilerMetadata', 'compilerArtefacts', 'network', 'offsetToLineColumnConverter'])
   await appManager.activatePlugin(['mainPanel', 'menuicons'])
-  await appManager.activatePlugin(['home', 'sidePanel', 'pluginManager', 'fileExplorers', 'settings', 'contextualListener', 'terminal'])
+  await appManager.activatePlugin(['home', 'sidePanel', 'hiddenPanel', 'pluginManager', 'fileExplorers', 'settings', 'contextualListener', 'scriptRunner', 'terminal'])
 
   // Set workspace after initial activation
   if (Array.isArray(workspace)) await appManager.activatePlugin(workspace)

--- a/src/app/components/hidden-panel.js
+++ b/src/app/components/hidden-panel.js
@@ -14,7 +14,7 @@ const profile = {
   displayName: 'Hidden Panel',
   description: '',
   version: packageJson.version,
-  methods: []
+  methods: ['addView', 'removeView']
 }
 
 export class HiddenPanel extends AbstractPanel {

--- a/src/app/panels/terminal.js
+++ b/src/app/panels/terminal.js
@@ -81,7 +81,7 @@ class Terminal extends Plugin {
       scopedCommands.log(`> ${script}`)
       self._shell(script, scopedCommands, function (error, output) {
         if (error) scopedCommands.error(error)
-        else scopedCommands.log(output)
+        else if (output) scopedCommands.log(output)
       })
     }, { activate: true })
     function basicFilter (value, query) { try { return value.indexOf(query) !== -1 } catch (e) { return false } }
@@ -97,6 +97,26 @@ class Terminal extends Plugin {
 
     if (opts.shell) self._shell = opts.shell // ???
     register(self)
+  }
+  onActivation () {
+    this.on('scriptRunner', 'log', (msg) => {
+      this.commands['log'].apply(this.commands, msg.data)
+    })
+    this.on('scriptRunner', 'info', (msg) => {
+      this.commands['info'].apply(this.commands, msg.data)
+    })
+    this.on('scriptRunner', 'warn', (msg) => {
+      this.commands['warn'].apply(this.commands, msg.data)
+    })
+    this.on('scriptRunner', 'error', (msg) => {
+      this.commands['error'].apply(this.commands, msg.data)
+    })
+  }
+  onDeactivation () {
+    this.off('scriptRunner', 'log')
+    this.off('scriptRunner', 'info')
+    this.off('scriptRunner', 'warn')
+    this.off('scriptRunner', 'error')
   }
   logHtml (html) {
     var command = this.commands['html']
@@ -124,6 +144,7 @@ class Terminal extends Plugin {
         ${self._view.input}
       </div>
     `
+
     self._view.icon = yo`
       <i onmouseenter=${hover} onmouseleave=${hover} onmousedown=${minimize}
       class="btn btn-secondary btn-sm align-items-center ${css.toggleTerminal} fas fa-angle-double-down" data-id="terminalToggleIcon"></i>`
@@ -659,17 +680,27 @@ class Terminal extends Plugin {
     }
     return self.commands[name]
   }
-  _shell (script, scopedCommands, done) { // default shell
+  async _shell (script, scopedCommands, done) { // default shell
     if (script.indexOf('remix:') === 0) {
       return done(null, 'This type of command has been deprecated and is not functionning anymore. Please run remix.help() to list available commands.')
     }
     var self = this
-    var context = domTerminalFeatures(self, scopedCommands, self.blockchain)
+    if (script.indexOf('remix.') === 0) {
+      // we keep the old feature. This will basically only be called when the command is querying the "remix" object.
+      // for all the other case, we use the Code Executor plugin
+      var context = domTerminalFeatures(self, scopedCommands, self.blockchain)
+      try {
+        var cmds = vm.createContext(Object.assign(self._jsSandboxContext, context, self._jsSandboxRegistered))
+        var result = vm.runInContext(script, cmds)
+        self._jsSandboxContext = Object.assign(cmds, context)
+        return done(null, result)
+      } catch (error) {
+        return done(error.message)
+      }
+    }
     try {
-      var cmds = vm.createContext(Object.assign(self._jsSandboxContext, context, self._jsSandboxRegistered))
-      var result = vm.runInContext(script, cmds)
-      self._jsSandboxContext = Object.assign(cmds, context)
-      done(null, result)
+      await this.call('scriptRunner', 'execute', script)
+      done()
     } catch (error) {
       done(error.message)
     }

--- a/src/remixAppManager.js
+++ b/src/remixAppManager.js
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events'
 import QueryParams from './lib/query-params'
 
 const requiredModules = [ // services + layout views + system views
-  'manager', 'compilerArtefacts', 'compilerMetadata', 'contextualListener', 'editor', 'offsetToLineColumnConverter', 'network', 'theme', 'fileManager', 'contentImport',
+  'manager', 'compilerArtefacts', 'compilerMetadata', 'contextualListener', 'editor', 'offsetToLineColumnConverter', 'network', 'theme', 'fileManager', 'contentImport', 'scriptRunner',
   'mainPanel', 'hiddenPanel', 'sidePanel', 'menuicons', 'fileExplorers',
   'terminal', 'settings', 'pluginManager']
 


### PR DESCRIPTION
This is done by running the script inside a dedicated plugin instead of using the npm module `vm-browserify`.
For the moment we loose support for Web3 Provider. This will be added in the next PR.

Important note, the plugin runs in the same domain as the app, we need to evaluate whether we really want that. Having a separate domain is ofc possible but require more devops and maintenance.