### PR TITLE
[minor] Fixing typo on sample smart contract

### DIFF
--- a/src/app/editor/example-contracts.js
+++ b/src/app/editor/example-contracts.js
@@ -4,7 +4,7 @@ const storage = `pragma solidity >=0.4.22 <0.7.0;
 
 /**
  * @title Storage
- * @dev Store & retreive value in a variable
+ * @dev Store & retrieve value in a variable
  */
 contract Storage {
 
@@ -22,7 +22,7 @@ contract Storage {
      * @dev Return value 
      * @return value of 'number'
      */
-    function retreive() public view returns (uint256){
+    function retrieve() public view returns (uint256){
         return number;
     }
 }`


### PR DESCRIPTION
Fixing typo on `example-contracts.js` contract
s/retreive/retrieve