### PR TITLE
Reject with a proper Error object

### DIFF
--- a/src/app/tabs/test-tab.js
+++ b/src/app/tabs/test-tab.js
@@ -162,7 +162,10 @@ module.exports = class TestTab extends ViewPlugin {
         usingWorker: canUseWorker(currentVersion)
       }
       remixTests.runTestSources(runningTest, compilerConfig, () => {}, () => {}, (error, result) => {
-        if (error) return reject(error)
+        if (error) {
+          error = typeof error !== 'string' ? JSON.stringify(error) : error
+          return reject(new Error(error))
+        }
         resolve(result)
       }, (url, cb) => {
         return this.compileTab.compileTabLogic.importFileCb(url, cb)


### PR DESCRIPTION
If promises reject without using `Error` (e.g also without the `message` attribute), remix plugin is not able to identify this has an exception and thus to rethrow the error to the client ( see https://github.com/ethereum/remix-plugin/blob/v0.2.0/projects/engine/src/plugin/iframe.ts#L92 ).

In this PR, error can be stringified JSON... this is discutable...