### PR TITLE
Don't call `setFileContent` 2 times

### DIFF
--- a/src/app/files/fileManager.js
+++ b/src/app/files/fileManager.js
@@ -355,7 +355,6 @@ class FileManager extends Plugin {
     if (this.currentRequest) {
       const canCall = await this.askUserPermission('writeFile', '')
       if (canCall) {
-        this._setFileInternal(path, content)
         // inform the user about modification after permission is granted and even if permission was saved before
         toaster(yo`
           <div>


### PR DESCRIPTION
somehow that seems to break the e2e test `Should debug Ropsten transaction with source highlighting using the source verifier service and MetaMask`