### PR TITLE
docs: fix link to remix-tests current repo

### DIFF
--- a/docs/unittesting.md
+++ b/docs/unittesting.md
@@ -95,6 +95,6 @@ Remix-tests
 
 `remix-tests` is the module which works underneath of remix-ide `Solidity Unit Testing` plugin. 
 
-`remix-tests` is an [NPM package](https://www.npmjs.com/package/remix-tests). It can also be used as  a CLI/CI solution, supporting node.js. Find more information about this type of usage in the [remix-tests repository](https://github.com/ethereum/remix/tree/master/remix-tests#as-command-line-interface)
+`remix-tests` is an [NPM package](https://www.npmjs.com/package/remix-tests). It can also be used as  a CLI/CI solution, supporting node.js. Find more information about this type of usage in the [remix-tests repository](https://github.com/ethereum/remix-project/tree/master/libs/remix-tests#as-command-line-interface)
 
 For CI implementation example, see [Su Squares contract](https://github.com/su-squares/ethereum-contract/tree/e542f37d4f8f6c7b07d90a6554424268384a4186) and [Travis build](https://travis-ci.org/su-squares/ethereum-contract/builds/446186067) that uses `remix-tests` for continuous integration testing.


### PR DESCRIPTION
https://remix-ide.readthedocs.io/en/latest/unittesting.html#remix-tests links to the old repo. 

this remedies that.