### PR TITLE
Fixed issues with example code

### DIFF
--- a/docs/tutorial_debug.md
+++ b/docs/tutorial_debug.md
@@ -24,7 +24,7 @@ contract Donation {
         owner = msg.sender;
     }
 
-    function donate() payable  public {
+    function donate() public payable {
         addGiver(msg.value);
     }
 
@@ -193,7 +193,7 @@ Here's an example of this issue.  If you are debugging the following contract:
 pragma solidity >=0.5.1 <0.6.0;
 
 contract ctr {
-    function hid () public {
+    function hid() public {
         uint p = 45;
         uint m;
         m = 89;


### PR DESCRIPTION
Extraneous space in line 196: function hid () -> function hid() / I believe public keyword goes before payable keyword in line 27