### PR TITLE
Replace "step number" with "program counter"

### DIFF
--- a/docs/debugger.md
+++ b/docs/debugger.md
@@ -67,7 +67,7 @@ These are the state variables of the contract.
 ![](images/a-debug-sol-state.png)
 
 ### Opcodes
-This panel shows the step number and the **opcode** that the debugger is currently on.
+This panel shows the program counter and the **opcode** that the debugger is currently on.
 
 ![](images/a-debug-opcodes1.png)
 


### PR DESCRIPTION
"Step number" is not as specific as "program counter". It leads to confusions:

https://ethereum.stackexchange.com/questions/109354/is-the-vm-trace-step-in-the-remix-debugger-the-program-counter