### PR TITLE
Fixed bug in bash code to install remix-tests globally

### DIFF
--- a/docs/unittestingAsCLI.md
+++ b/docs/unittestingAsCLI.md
@@ -16,7 +16,7 @@ You can install it using NPM:
 
 * As a global NPM module:
 
-`npm -g install @remix-project/remix-tests`
+`npm install -g @remix-project/remix-tests`
 
 To confirm installation, run:
 ```


### PR DESCRIPTION
npm -g install @remix-project/remix-tests doesn't work; global option should go after install like so:
npm install -g @remix-project/remix-tests