### PR TITLE
Fix internal link and image render

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,6 @@ extensions = ['myst_parser'] # required for sphinx v3.0.0
 # suppress warnings caused by non-consecutive header
 # see more details here https://myst-parser.readthedocs.io/en/latest/faq/index.html#suppress-warnings
 suppress_warnings = ['myst.header']
-myst_disable_syntax = ['image']
 
 # myst will ignore all the internal links by default
 # see more details here https://myst-parser.readthedocs.io/en/latest/configuration.html?highlight=myst_all_links_external#global-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,8 +31,14 @@ import os
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['myst_parser'] # required for sphinx v3.0.0
+
+# suppress warnings caused by non-consecutive header
+# see more details here https://myst-parser.readthedocs.io/en/latest/faq/index.html#suppress-warnings
 suppress_warnings = ['myst.header']
 myst_disable_syntax = ['image']
+
+# myst will ignore all the internal links by default
+# see more details here https://myst-parser.readthedocs.io/en/latest/configuration.html?highlight=myst_all_links_external#global-configuration
 myst_all_links_external = True
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ import os
 extensions = ['myst_parser'] # required for sphinx v3.0.0
 suppress_warnings = ['myst.header']
 myst_disable_syntax = ['image']
+myst_all_links_external = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
The images not render correctly.
![image](https://user-images.githubusercontent.com/18543527/194860152-17fc1d81-e7d0-438b-ad74-673fc4102e15.png)

I added `myst_disable_syntax = ['image']` into conf.py in pr #3117  , because I wanted to remove the alt string which was duplicated with the image string. But it also caused the image render issue. I think this is the image issue @ryestew metioned in pr #3118 .

Now I removed `myst_disable_syntax = ['image']`, and tested it again, it rendered correctly.

There is another issue I found when I trying to fix the image issue, which also caused by pr #3117 . 

link text
![image](https://user-images.githubusercontent.com/18543527/193441085-75e1ffb5-dcdf-4648-a205-a81c9297886a.png)
will become like this
![image](https://user-images.githubusercontent.com/18543527/193441115-ffb48e54-b20d-4aa0-9edf-ebaee05f9a1d.png)
 
`myst` will ignore all the internal links by default. Add this `myst_all_links_external = True` into conf.py will fix it.

Sorry for my careless work, I should test it more carefully.


