### PR TITLE
Fixed a broken link for examples in unittesting.md

### DIFF
--- a/docs/unittesting.md
+++ b/docs/unittesting.md
@@ -148,7 +148,8 @@ function checkSenderIs0AndValueis10 () public payable {
 
 Regarding `gas`, Remix estimates the required gas for each transaction internally. Still if a contract deployment fails with `Out-of-Gas` error, it tries to redeploy it by doubling the gas. Deployment failing with double gas will show error: ```contract deployment failed after trying twice: The contract code couldn't be stored, please check your gas limit```
 
-Various test examples can be seen in [examples](./unittesting_examples) section.
+Various test examples can be seen in [examples](https://remix-ide.readthedocs.io/en/latest/unittesting_examples.html) section.
+
 
 
 Points to remember


### PR DESCRIPTION
If you click on "How to use" in the Unit Testing tab in Remix it leads to a broken examples link in which I updated. Attached images for reference below. 

![Screenshot 2024-02-07 074613](https://github.com/ethereum/remix-ide/assets/95197857/875f133d-cfb5-418d-a279-8449a35b499a)

![Screenshot 2024-02-07 074627](https://github.com/ethereum/remix-ide/assets/95197857/969457dc-02b4-4952-bdd7-0f689e529e8d)

![Screenshot 2024-02-07 074634](https://github.com/ethereum/remix-ide/assets/95197857/f8ddaf4b-3671-47cd-9988-a8e4b067eb42)

![Screenshot 2024-02-07 075427](https://github.com/ethereum/remix-ide/assets/95197857/617cab16-e420-475e-a535-83ec5d4ecf9b)