### PR TITLE
feat: Cookbook Onboard (AI Assistant) integration

### DIFF
--- a/docs/_static/js/cookbook-integration.js
+++ b/docs/_static/js/cookbook-integration.js
@@ -1,0 +1,23 @@
+(function() {
+  // Cookbook Onboard (AI Assistant). API key is public so it's fine to just hardcode it here.
+  var COOKBOOK_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NmE4MzQyZTg2NDM1ZGEyMGE1NDc5ODciLCJpYXQiOjE3MjIyOTk0MzgsImV4cCI6MjAzNzg3NTQzOH0.v-569WVNKHsQX2uDPyHJCOjXz811_iSlyitaKgqmg2U";
+
+  document.addEventListener('DOMContentLoaded', function() {
+    var element = document.getElementById('__cookbook');
+    if (!element) {
+      element = document.createElement('div');
+      element.id = '__cookbook';
+      element.dataset.apiKey = COOKBOOK_API_KEY;
+      document.body.appendChild(element);
+    }
+
+    var script = document.getElementById('__cookbook-script');
+    if (!script) {
+      script = document.createElement('script');
+      script.src = 'https://cdn.jsdelivr.net/npm/@cookbookdev/docsbot/dist/standalone/index.cjs.js';
+      script.id = '__cookbook-script';
+      script.defer = true;
+      document.body.appendChild(script);
+    }
+  });
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,7 +166,8 @@ html_js_files = [
     "js/constants.js",
     "js/utils.js",
     "js/loaders.js",
-    "js/initialize.js"
+    "js/initialize.js",
+    "js/cookbook-integration.js"
 ]
 
 html_css_files = ["css/fonts.css", "css/tokens.css", "css/custom.css"]


### PR DESCRIPTION
The AI assistant and co-pilot is trained on all existing Remix resources (source code, docs website, etc) and is available as a standalone modal, embeddable as a button on any page (recommended for technical docs). It answers developer questions about using Remix, acting as an enhanced and streamlined technical documentation search tool as well as a Solidity coding co-pilot.

Ask Cookbook AI could also access context from thousands of data sources indexed by Cookbook.dev in addition to Remix-specific data sources, providing the best blockchain developer-focused answers of any chatbot on the market. Cookbook will assist in the tuning and calibration of the AI assistant to ensure the highest answer quality.

## Preview
https://docsbot-demo-git-remix-cookbookdev.vercel.app/

![image](https://github.com/user-attachments/assets/f52a0bdf-f590-47e4-bb76-26a020ab8c21)