### PR TITLE
Updated custom.css to accomodate switch-menus

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -355,12 +355,11 @@ nav.wy-nav-shift {
 /* Remove background from the search container */
 .wy-side-nav-search {
   display: flex;
-  flex-direction: row-reverse;
-  align-items: end;
+  flex-direction: column;
+  align-items: stretch;
   background: none !important;
-  margin: 5rem 0 0;
-  padding: 0 var(--space-vertical-menu-pad-x);
   margin: 2.875rem 0 0 !important;
+  padding: 0 var(--space-vertical-menu-pad-x);
 }
 
 .wy-side-scroll hr {


### PR DESCRIPTION
Related Issue - #6076 (In remix-project repository)

Version and Language Dropdowns in Sidebar Are Nearly Invisible Due to Low Contrast

The _switch-menu_ element is dynamically generated but, the _wy-side-nav-search_ is supposed to be flex row which causes both the elements to be rendered side-by-side and causes space distortion.

**FIX** :  Changed the _wy-side-nav-search_ flex-direction to column and alignment to stretch.

Should fix this issue.